### PR TITLE
Add tracing of new constraints and columns to enable #9

### DIFF
--- a/.github/workflows/generate_sample_report.yml
+++ b/.github/workflows/generate_sample_report.yml
@@ -1,0 +1,51 @@
+name: Generate sample reports
+
+on:
+  pull_request:
+    branches:
+      - main
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  post_locktrace_markdown:
+    runs-on: ubuntu-latest
+    name: Post a report sample to the pull request
+    env:
+      PGPASS: postgres
+    services:
+      postgres:
+        image: postgres:16
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        options: >-
+          --health-cmd="pg_isready -U postgres" --health-interval=10s --health-timeout=5s --health-retries=5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install eugene
+        run: cargo install --path .
+      - name: Set up psql
+        run: sudo apt-get install -y postgresql-client
+      - name: Make ~/.pgpass
+        run: echo "localhost:5432:*:postgres:$PGPASS" > ~/.pgpass && chmod 600 ~/.pgpass
+      - name: Init testdb
+        run: psql --host localhost --port 5432 -U postgres < db-initscripts/init-testdb.sql
+      - name: Run eugene to generate example report
+        run: eugene trace -e -d example-db -f markdown examples/add_authors.sql > report.md
+      - name: Post report as comment to pull request
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.SUBMIT_COMMENT_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('report.md', 'utf8');
+            github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: report
+            });
+        

--- a/.github/workflows/lint_and_fmt_pull_req.yml
+++ b/.github/workflows/lint_and_fmt_pull_req.yml
@@ -1,0 +1,24 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  check_formatting:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+  check_clippy:
+    name: Check clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/pull_req_rust.yml
+++ b/.github/workflows/pull_req_rust.yml
@@ -8,57 +8,87 @@ on:
 env:
   CARGO_TERM_COLOR: always
 jobs:
-  check_formatting:
+  run_tests_ubuntu:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-  check_clippy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
-  run_tests:
-    runs-on: ${{ matrix.os }}
+    name: Test postgres-${{ matrix.pgversion }}
     strategy:
-      matrix: {os: [ubuntu-latest, macos-latest, windows-latest] }
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run tests
-        run: cargo test --all-targets --all-features
-  post_locktrace_markdown:
-    runs-on: ubuntu-latest
+      matrix:
+        pgversion:
+          - "12"
+          - "13"
+          - "14"
+          - "15"
+          - "16"
     env:
       PGPASS: postgres
     services:
       postgres:
-        image: postgres:16
+        image: postgres:${{ matrix.pgversion }}
         ports:
           - 5432:5432
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
+        options: >-
+          --health-cmd="pg_isready -U postgres" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
       - uses: actions/checkout@v4
-      - name: Install eugene
-        run: cargo install --path .
-      - name: Run eugene to create books
-        run: eugene trace -d postgres -c examples/create_books.sql
-      - name: Run eugene to generate example report
-        run: eugene trace -e -d postgres -f markdown examples/add_authors.sql > report.md
-      - name: Post report as comment to pull request
-        uses: actions/github-script@v4
-        with:
-          github-token: ${{ secrets.SUBMIT_COMMENT_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const report = fs.readFileSync('report.md', 'utf8');
-            github.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: report
-            });
+      - name: Set up psql
+        run: sudo apt-get install -y postgresql-client
+      - name: Make ~/.pgpass
+        run: echo "localhost:5432:*:postgres:$PGPASS" > ~/.pgpass && chmod 600 ~/.pgpass
+      - name: Init testdb
+        run: psql --host localhost --port 5432 -U postgres < db-initscripts/init-testdb.sql
+      - name: Run tests
+        run: cargo test --all-targets --all-features
+  run_tests_macos:
+    name: Test on macos
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install psql and postgres
+        run: brew install postgresql
+      - name: Init postgres db
+        run: |
+          initdb -E UTF-8 -U postgres $HOME/pgdata
+          pg_ctl -D $HOME/pgdata start
+      - name: Give postgres time to start
+        run: sleep 10
+      - name: Set up ~/.pgpass
+        run: |
+          psql -U postgres -c "ALTER USER postgres WITH PASSWORD 'postgres';"
+          echo "localhost:5432:*:postgres:postgres" > ~/.pgpass && chmod 600 ~/.pgpass
+      - name: Init testdb
+        run: psql -U postgres < db-initscripts/init-testdb.sql
+      - name: Run tests
+        run: cargo test --all-targets --all-features
+      - name: Stop postgres
+        run: pg_ctl -D $HOME/pgdata stop
+  run_tests_windows:
+    name: Test on Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install postgres with choco
+        shell: bash
+        run: |
+          choco install postgresql16 --params "/Password:postgres"
+          echo 'C:\Program Files\PostgreSQL\16\bin' >> $GITHUB_PATH
+          echo 'C:\Program Files\PostgreSQL\16\lib' >> $GITHUB_PATH
+      - name: Start postgres service
+        shell: pwsh
+        run: Start-Service postgresql-x64-16
+      - name: Give postgres time to start
+        shell: pwsh
+        run: Start-Sleep -s 10
+      - name: Init testdb
+        shell: bash
+        env:
+          PGPASSWORD: postgres
+        run: |
+          mkdir -p $APPDATA/postgresql
+          echo "localhost:5432:*:postgres:postgres" > $APPDATA/postgresql/pgpass.conf          
+          psql -U postgres < db-initscripts/init-testdb.sql
+      - name: Run tests
+        run: cargo test --all-targets --all-features

--- a/db-initscripts/init-testdb.sql
+++ b/db-initscripts/init-testdb.sql
@@ -1,0 +1,24 @@
+CREATE DATABASE test_db;
+CREATE DATABASE "example-db";
+
+\c test_db
+
+CREATE TABLE books
+(
+    id    SERIAL PRIMARY KEY,
+    title text
+);
+
+CREATE TABLE for_checking_modified_constraints (
+    id    SERIAL PRIMARY KEY,
+    title text check (length(title) < 10),
+    book_id integer references books(id)
+);
+
+\c "example-db"
+
+CREATE TABLE books
+(
+    id    SERIAL PRIMARY KEY,
+    title text
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,11 @@ services:
     ports:
       - '127.0.0.1:5432:5432'
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pg_data:/var/lib/postgresql/data
+      - ./db-initscripts:/docker-entrypoint-initdb.d
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
 
 volumes:
-  pgdata:
+  pg_data:

--- a/examples/add_authors.sql
+++ b/examples/add_authors.sql
@@ -1,5 +1,7 @@
-create table authors(name text not null);
+create table authors(id serial primary key, name text not null);
 alter table books alter column title set not null;
+alter table books add column author_id integer not null;
+alter table books add foreign key (author_id) references authors(id);
 select pg_sleep(1);
 select * from books;
 

--- a/examples/create_books.sql
+++ b/examples/create_books.sql
@@ -1,1 +1,0 @@
-create table books (id serial primary key, title text);

--- a/src/output.rs
+++ b/src/output.rs
@@ -304,6 +304,7 @@ impl FullTraceData {
                 }
                 time_diff += statement.duration_millis;
             }
+            result.push('\n');
             if dangerous_locks > 0 {
                 result.push_str("### Dangerous locks found\n\n");
                 for lock in self

--- a/src/pg_types.rs
+++ b/src/pg_types.rs
@@ -1,3 +1,5 @@
+/// Postgres constaint types
+pub mod contype;
 /// This module contains data about postgres lock modes and their capabilities.
 pub mod lock_modes;
 /// Locks targeting database objects like tables or indexes, together with their lock modes.

--- a/src/pg_types/contype.rs
+++ b/src/pg_types/contype.rs
@@ -1,0 +1,32 @@
+use anyhow::anyhow;
+
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
+pub enum Contype {
+    Check,
+    ForeignKey,
+    PrimaryKey,
+    Unique,
+    Exclusion,
+}
+
+impl Contype {
+    pub fn from_char(c: char) -> anyhow::Result<Self> {
+        match c {
+            'c' => Ok(Contype::Check),
+            'f' => Ok(Contype::ForeignKey),
+            'p' => Ok(Contype::PrimaryKey),
+            'u' => Ok(Contype::Unique),
+            'x' => Ok(Contype::Exclusion),
+            _ => Err(anyhow!("Invalid constraint type: {}", c)),
+        }
+    }
+    pub fn to_display(&self) -> &'static str {
+        match self {
+            Contype::Check => "CHECK",
+            Contype::ForeignKey => "FOREIGN KEY",
+            Contype::PrimaryKey => "PRIMARY KEY",
+            Contype::Unique => "UNIQUE",
+            Contype::Exclusion => "EXCLUSION",
+        }
+    }
+}

--- a/src/tracing/tracer.rs
+++ b/src/tracing/tracer.rs
@@ -1,11 +1,13 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Local};
+use itertools::Itertools;
 use postgres::types::Oid;
 use postgres::Transaction;
 
+use crate::pg_types::contype::Contype;
 use crate::pg_types::locks::{Lock, LockableTarget};
 
 /// A trace of a single SQL statement, including the locks taken and the duration of the statement.
@@ -19,6 +21,14 @@ pub struct SqlStatementTrace {
     pub(crate) start_time: Instant,
     /// The duration of the statement.
     pub(crate) duration: Duration,
+    /// Columns that were added
+    pub(crate) added_columns: Vec<(ColumnIdentifier, ColumnMetadata)>,
+    /// Columns that were modified
+    pub(crate) modified_columns: Vec<(ColumnIdentifier, ModifiedColumn)>,
+    /// Constraints that were added
+    pub(crate) added_constraints: Vec<Constraint>,
+    /// Constraints that were modified
+    pub(crate) modified_constraints: Vec<(Oid, ModifiedConstraint)>,
 }
 
 /// Enumerate all locks owned by the current transaction.
@@ -72,6 +82,42 @@ fn find_new_locks(old_locks: &HashSet<Lock>, new_locks: &HashSet<Lock>) -> HashS
         .collect()
 }
 
+#[derive(Eq, PartialEq, Debug, Clone, Copy, Hash)]
+pub struct ColumnIdentifier {
+    oid: Oid,
+    attnum: i32,
+}
+
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub struct ColumnMetadata {
+    name: String,
+    nullable: bool,
+    typename: String,
+    max_len: Option<u32>,
+}
+
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub struct ModifiedColumn {
+    old: ColumnMetadata,
+    new: ColumnMetadata,
+}
+
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub struct Constraint {
+    schema_name: String,
+    table_name: String,
+    constraint_type: Contype,
+    name: String,
+    expression: Option<String>,
+    valid: bool,
+}
+
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub struct ModifiedConstraint {
+    old: Constraint,
+    new: Constraint,
+}
+
 /// A trace of a transaction, including all SQL statements executed and the locks taken by each one.
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub struct TxLockTracer {
@@ -85,35 +131,181 @@ pub struct TxLockTracer {
     all_locks: HashSet<Lock>,
     /// The time the trace started
     pub(crate) trace_start: DateTime<Local>,
+    /// All columns in the database, along with their metadata
+    columns: HashMap<ColumnIdentifier, ColumnMetadata>,
+    /// All constraints in the database
+    constraints: HashMap<Oid, Constraint>,
 }
 
 impl TxLockTracer {
     /// Trace a single SQL statement, recording the locks taken and the duration of the statement.
     pub fn trace_sql_statement(&mut self, tx: &mut Transaction, sql: &str) -> Result<()> {
         let start_time = Instant::now();
+        let oid_vec = self.initial_objects.iter().copied().collect_vec();
         tx.execute(sql, &[])
             .map_err(|err| anyhow!("{err} while executing {}", sql.to_owned()))?;
         let duration = start_time.elapsed();
         let locks_taken = find_relevant_locks_in_current_transaction(tx, &self.initial_objects)?;
         let new_locks = find_new_locks(&self.all_locks, &locks_taken);
         self.all_locks.extend(locks_taken.iter().cloned());
+
+        let columns = fetch_all_columns(tx, &oid_vec)?;
+        let mut added_columns = Vec::new();
+        let mut modified_columns = Vec::new();
+        for (col_id, col) in columns.iter() {
+            if let Some(pre_existing) = self.columns.get(col_id) {
+                if pre_existing != col {
+                    modified_columns.push((
+                        *col_id,
+                        ModifiedColumn {
+                            new: col.clone(),
+                            old: pre_existing.clone(),
+                        },
+                    ));
+                }
+            } else {
+                added_columns.push((*col_id, col.clone()));
+            }
+        }
+        self.columns = columns;
+
+        let constraints = fetch_constraints(tx, &oid_vec)?;
+        let mut added_constraints = Vec::new();
+        let mut modified_constraints = Vec::new();
+
+        for (conid, con) in constraints.iter() {
+            if let Some(pre_existing) = self.constraints.get(conid) {
+                if pre_existing != con {
+                    modified_constraints.push((
+                        *conid,
+                        ModifiedConstraint {
+                            old: pre_existing.clone(),
+                            new: con.clone(),
+                        },
+                    ));
+                }
+            } else {
+                added_constraints.push(con.clone());
+            }
+        }
+        self.constraints = constraints;
+
         self.statements.push(SqlStatementTrace {
             sql: sql.to_string(),
             locks_taken: new_locks.into_iter().collect(),
             start_time,
             duration,
+            added_columns,
+            modified_columns,
+            added_constraints,
+            modified_constraints,
         });
         Ok(())
     }
-    pub fn new(name: Option<String>, initial_objects: HashSet<Oid>) -> Self {
+    pub fn new(
+        name: Option<String>,
+        initial_objects: HashSet<Oid>,
+        columns: HashMap<ColumnIdentifier, ColumnMetadata>,
+        constraints: HashMap<Oid, Constraint>,
+    ) -> Self {
         Self {
             name,
             initial_objects,
             statements: vec![],
             all_locks: HashSet::new(),
             trace_start: Local::now(),
+            columns,
+            constraints,
         }
     }
+}
+
+/// Fetch all non-system columns in the database
+fn fetch_all_columns(
+    tx: &mut Transaction,
+    oids: &[Oid],
+) -> Result<HashMap<ColumnIdentifier, ColumnMetadata>> {
+    let sql = "SELECT
+           a.attrelid as table_oid,
+           a.attnum as attnum,
+           a.attname as column_name,
+           a.attnotnull as not_null,
+           t.typname as type_name,
+           a.atttypmod as typmod
+         FROM pg_catalog.pg_attribute a
+           JOIN pg_catalog.pg_type t ON a.atttypid = t.oid
+           JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+           JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+         WHERE n.nspname NOT IN ('pg_catalog', 'information_schema') AND c.oid = ANY($1)
+         ";
+    let rows = tx.query(sql, &[&oids]).map_err(|err| anyhow!("{err}"))?;
+    rows.into_iter()
+        .map(|row| {
+            let table_oid: Oid = row.try_get(0)?;
+            let attnum: i16 = row.try_get(1)?;
+            let column_name: String = row.try_get(2)?;
+            let not_null: bool = row.try_get(3)?;
+            let type_name: String = row.try_get(4)?;
+            let typmod: i32 = row.try_get(5)?;
+            let max_len = if typmod > 0 {
+                Some((typmod - 4) as u32)
+            } else {
+                None
+            };
+            let identifier = ColumnIdentifier {
+                oid: table_oid,
+                attnum: attnum as i32,
+            };
+            let metadata = ColumnMetadata {
+                name: column_name,
+                nullable: !not_null,
+                typename: type_name,
+                max_len,
+            };
+            Ok((identifier, metadata))
+        })
+        .collect()
+}
+
+/// Fetch all non-system constraints in the database
+fn fetch_constraints(tx: &mut Transaction, oids: &[Oid]) -> Result<HashMap<Oid, Constraint>> {
+    let sql = "SELECT
+           n.nspname as schema_name,
+           c.relname as table_name,
+           con.oid as con_oid,
+           con.conname as constraint_name,
+           con.contype as constraint_type,
+           con.convalidated as valid,
+           pg_get_constraintdef(con.oid) as expression
+         FROM pg_catalog.pg_constraint con
+           JOIN pg_catalog.pg_class c ON con.conrelid = c.oid
+           JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+         WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+          AND con.conrelid = ANY($1) OR con.confrelid = ANY($1)
+         ";
+    let rows = tx.query(sql, &[&oids]).map_err(|err| anyhow!("{err}"))?;
+
+    rows.into_iter()
+        .map(|row| {
+            let schema_name: String = row.try_get(0)?;
+            let table_name: String = row.try_get(1)?;
+            let con_oid: Oid = row.try_get(2)?;
+            let constraint_name: String = row.try_get(3)?;
+            let constraint_type_byte: i8 = row.try_get(4)?;
+            let constraint_type = Contype::from_char((constraint_type_byte as u8) as char)?;
+            let valid: bool = row.try_get(5)?;
+            let expression: Option<String> = row.try_get(6)?;
+            let constraint = Constraint {
+                schema_name,
+                table_name,
+                constraint_type,
+                name: constraint_name,
+                expression,
+                valid,
+            };
+            Ok((con_oid, constraint))
+        })
+        .collect()
 }
 
 /// Fetch all user owned lockable objects in the database, skipping the system schemas.
@@ -148,13 +340,130 @@ pub fn trace_transaction<S: AsRef<str>>(
     tx: &mut Transaction,
     sql_statements: impl Iterator<Item = S>,
 ) -> Result<TxLockTracer> {
-    let initial_objects = fetch_lockable_objects(tx)?
+    let initial_objects: HashSet<_> = fetch_lockable_objects(tx)?
         .into_iter()
         .map(|obj| obj.oid)
         .collect();
-    let mut trace = TxLockTracer::new(name, initial_objects);
+    let oid_vec: Vec<_> = initial_objects.iter().copied().collect();
+    let columns = fetch_all_columns(tx, &oid_vec)?;
+    let constraints = fetch_constraints(tx, &oid_vec)?;
+    let mut trace = TxLockTracer::new(name, initial_objects, columns, constraints);
     for sql in sql_statements {
         trace.trace_sql_statement(tx, sql.as_ref().trim())?;
     }
     Ok(trace)
+}
+
+#[cfg(test)]
+mod tests {
+    use postgres::{Client, NoTls};
+
+    fn get_client() -> Client {
+        Client::connect(
+            "host=localhost dbname=test_db password=postgres user=postgres",
+            NoTls,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_that_we_discover_modified_nullability() {
+        let mut client = get_client();
+        let mut tx = client.transaction().unwrap();
+        let trace = super::trace_transaction(
+            None,
+            &mut tx,
+            vec!["alter table books alter column title set not null"].into_iter(),
+        )
+        .unwrap();
+        let modification = &trace.statements[0].modified_columns[0].1;
+        assert!(modification.old.nullable);
+        assert!(!modification.new.nullable);
+    }
+
+    #[test]
+    fn test_that_we_discover_new_valid_check_constraint() {
+        let mut client = get_client();
+        let mut tx = client.transaction().unwrap();
+        let trace = super::trace_transaction(
+            None,
+            &mut tx,
+            vec!["alter table books add constraint check_title check (title <> '')"].into_iter(),
+        )
+        .unwrap();
+        let constraint = &trace.statements[0].added_constraints[0];
+        assert_eq!(constraint.constraint_type, super::Contype::Check);
+        assert!(constraint.valid);
+        assert_eq!(
+            constraint.expression.clone().unwrap().as_str(),
+            "CHECK ((title <> ''::text))"
+        );
+    }
+
+    #[test]
+    fn test_that_we_discover_new_foreign_key_constraint() {
+        let mut client = get_client();
+        let mut tx = client.transaction().unwrap();
+        let trace = super::trace_transaction(
+            None, &mut tx, vec![
+                "create table authors (id serial primary key);",
+                "alter table books add column author_id integer;",
+                "alter table books add constraint fk_author foreign key (author_id) references authors(id)",
+            ].into_iter(),
+        ).unwrap();
+        let constraint = &trace.statements[2].added_constraints[0];
+        assert_eq!(constraint.constraint_type, super::Contype::ForeignKey);
+        assert!(constraint.valid);
+        assert_eq!(
+            constraint.expression.clone().unwrap().as_str(),
+            "FOREIGN KEY (author_id) REFERENCES authors(id)"
+        );
+    }
+
+    #[test]
+    fn test_that_we_discover_new_not_valid_check_constraint() {
+        let mut client = get_client();
+        let mut tx = client.transaction().unwrap();
+        let trace = super::trace_transaction(
+            None,
+            &mut tx,
+            vec!["alter table books add constraint check_title check (title <> '') not valid"]
+                .into_iter(),
+        )
+        .unwrap();
+        let constraint = &trace.statements[0].added_constraints[0];
+        assert_eq!(constraint.constraint_type, super::Contype::Check);
+        assert!(!constraint.valid);
+    }
+
+    #[test]
+    fn test_that_we_discover_column_renames() {
+        let mut client = get_client();
+        let mut tx = client.transaction().unwrap();
+        let trace = super::trace_transaction(
+            None,
+            &mut tx,
+            vec!["alter table books rename column title to book_title"].into_iter(),
+        )
+        .unwrap();
+        let modification = &trace.statements[0].modified_columns[0].1;
+        assert_eq!(modification.old.name, "title");
+        assert_eq!(modification.new.name, "book_title");
+    }
+
+    #[test]
+    fn test_that_we_discover_column_type_changes() {
+        let mut client = get_client();
+        let mut tx = client.transaction().unwrap();
+        let trace = super::trace_transaction(
+            None,
+            &mut tx,
+            vec!["alter table books alter column title type varchar(255)"].into_iter(),
+        )
+        .unwrap();
+        let modification = &trace.statements[0].modified_columns[0].1;
+        assert_eq!(modification.old.typename, "text");
+        assert_eq!(modification.new.typename, "varchar");
+        assert_eq!(modification.new.max_len.unwrap(), 255);
+    }
 }


### PR DESCRIPTION
This should enable us to add quite a few of the strong_migrations-style checks, where we can detect patterns like unsafely changing a column type, then suggest a better way.