### PR TITLE
Mvp lint

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=CARGO_PKG_VERSION={}",
+        env!("CARGO_PKG_VERSION")
+    );
+}

--- a/examples/widen_type.md
+++ b/examples/widen_type.md
@@ -111,7 +111,7 @@ ID: `E5`
 
 A column was changed to a data type that isn't binary compatible. This causes a full table rewrite while holding a lock that prevents all other use of the table. A safer way is: Add a new column, update it in batches, and drop the old column.
 
-The column `price` in the table `public.books` was changed from type `int4` to `int8`. This always requires an `AccessExclusiveLock` that will block all other transactions from using the table, and for some type changes, it causes a time-consuming table rewrite.
+The column `price` in the table `public.books` was changed from type `int4` to `int8`. This requires an `AccessExclusiveLock` that will block all other transactions from using the table while it is being rewritten.
 
 #### Creating a new index on an existing table
 

--- a/src/bin/eugene.rs
+++ b/src/bin/eugene.rs
@@ -38,6 +38,16 @@ enum Commands {
         #[arg(short = 'v', long = "var")]
         placeholders: Vec<String>,
         /// Ignore the hints with these IDs, use `eugene hints` to see available hints. Can be used multiple times.
+        ///
+        /// Example: `eugene lint -i E3 -i E4`
+        ///
+        /// For finer granularity, you can annotate a SQL statement with an ignore-instruction like this:
+        ///
+        /// -- eugene-ignore: E3, E4
+        ///
+        /// alter table foo add column bar json;
+        ///
+        /// This will ignore hints E3 and E4 for this statement only.
         #[arg(short = 'i', long = "ignore")]
         ignored_hints: Vec<String>,
     },

--- a/src/bin/eugene.rs
+++ b/src/bin/eugene.rs
@@ -2,16 +2,18 @@ use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand};
 use serde::Serialize;
 
+use eugene::lints::apply_ignore_list;
 use eugene::output::output_format::GenericHint;
 use eugene::output::{DetailedLockMode, LockModesWrapper, TerseLockMode};
 use eugene::pg_types::lock_modes;
 use eugene::pgpass::read_pgpass_file;
-use eugene::{output, perform_trace, ConnectionSettings, TraceSettings};
+use eugene::sqltext::{read_sql_statements, resolve_placeholders};
+use eugene::{output, parse_placeholders, perform_trace, ConnectionSettings, TraceSettings};
 
 #[derive(Parser)]
 #[command(name = "eugene")]
 #[command(about = "Careful with That Lock, Eugene")]
-#[command(version = "0.1.0")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
 #[command(
     long_about = "eugene is a proof of concept tool for detecting dangerous locks taken by SQL migration scripts
 
@@ -28,6 +30,17 @@ struct Eugene {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Lint SQL migration script by analyzing syntax tree and matching rules instead of running it.
+    Lint {
+        /// Path to SQL migration script, or '-' to read from stdin
+        path: String,
+        /// Provide name=value for replacing ${name} with value in the SQL script. Can be used multiple times.
+        #[arg(short = 'v', long = "var")]
+        placeholders: Vec<String>,
+        /// Ignore the hints with these IDs, use `eugene hints` to see available hints. Can be used multiple times.
+        #[arg(short = 'i', long = "ignore")]
+        ignored_hints: Vec<String>,
+    },
     /// Trace locks taken by statements SQL migration script. Reads password from $PGPASS environment variable.
     Trace {
         /// Path to SQL migration script, or '-' to read from stdin
@@ -108,8 +121,7 @@ impl TryFrom<ProvidedConnectionSettings> for ConnectionSettings {
         let password = if let Ok(password) = std::env::var("PGPASS") {
             password
         } else {
-            let pgpass = read_pgpass_file()?;
-            pgpass
+            read_pgpass_file()?
                 .find_password(&value.host, value.port, &value.database, &value.user)
                 .context("No password found, provide PGPASS as environment variable or set up pgpassfile: https://www.postgresql.org/docs/current/libpq-pgpass.html")?
                 .to_string()
@@ -176,6 +188,20 @@ impl TryFrom<String> for TraceFormat {
 pub fn main() -> Result<()> {
     let args = Eugene::parse();
     match args.command {
+        Some(Commands::Lint {
+            path,
+            placeholders,
+            ignored_hints,
+        }) => {
+            let sql = read_sql_statements(&path)?;
+            let placeholders = parse_placeholders(&placeholders)?;
+            let sql = resolve_placeholders(&sql, &placeholders)?;
+            let report = eugene::lints::lint(sql)?;
+            let report = apply_ignore_list(&report, &ignored_hints);
+            let out = serde_json::to_string_pretty(&report)?;
+            println!("{}", out);
+            Ok(())
+        }
         Some(Commands::Trace {
             user,
             database,
@@ -219,7 +245,10 @@ pub fn main() -> Result<()> {
             Ok(())
         }
         Some(Commands::Hints { .. }) => {
-            let hints: Vec<_> = eugene::hints::HINTS.iter().map(GenericHint::from).collect();
+            let hints: Vec<_> = eugene::hints::all_hints()
+                .iter()
+                .map(GenericHint::from)
+                .collect();
             let hints = HintContainer { hints };
             println!("{}", serde_json::to_string_pretty(&hints)?);
             Ok(())

--- a/src/hint_data.rs
+++ b/src/hint_data.rs
@@ -1,0 +1,80 @@
+pub struct StaticHintData {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub condition: &'static str,
+    pub effect: &'static str,
+    pub workaround: &'static str,
+}
+pub const VALIDATE_CONSTRAINT_WITH_LOCK: StaticHintData = StaticHintData {
+    id: "E1",
+    name: "Validating table with a new constraint",
+    condition: "A new constraint was added and it is already `VALID`",
+    effect: "This blocks all table access until all rows are validated",
+    workaround: "Add the constraint as `NOT VALID` and validate it with `ALTER TABLE ... VALIDATE CONSTRAINT` later",
+};
+pub const MAKE_COLUMN_NOT_NULLABLE_WITH_LOCK: StaticHintData = StaticHintData {
+    id: "E2",
+    name: "Validating table with a new `NOT NULL` column",
+    condition: "A column was changed from `NULL` to `NOT NULL`",
+    workaround: "Add a `CHECK` constraint as `NOT VALID`, validate it later, then make the column `NOT NULL`",
+    effect: "This blocks all table access until all rows are validated",
+};
+pub const ADD_JSON_COLUMN: StaticHintData = StaticHintData {
+    id: "E3",
+    name: "Add a new JSON column",
+    condition: "A new column of type `json` was added to a table",
+    workaround: "Use the `jsonb` type instead, it supports all use-cases of `json` and is more robust and compact",
+    effect: "This breaks `SELECT DISTINCT` queries or other operations that need equality checks on the column",
+};
+pub const RUNNING_STATEMENT_WHILE_HOLDING_ACCESS_EXCLUSIVE: StaticHintData = StaticHintData {
+    id: "E4",
+    name: "Running more statements after taking `AccessExclusiveLock`",
+    condition: "A transaction that holds an `AccessExclusiveLock` started a new statement",
+    workaround: "Run this statement in a new transaction",
+    effect: "This blocks all access to the table for the duration of this statement",
+};
+pub const TYPE_CHANGE_REQUIRES_TABLE_REWRITE: StaticHintData = StaticHintData {
+    id: "E5",
+    name: "Type change requiring table rewrite",
+    condition: "A column was changed to a data type that isn't binary compatible",
+    workaround: "Add a new column, update it in batches, and drop the old column",
+    effect: "This causes a full table rewrite while holding a lock that prevents all other use of the table",
+};
+pub const NEW_INDEX_ON_EXISTING_TABLE_IS_NONCONCURRENT: StaticHintData = StaticHintData {
+    id: "E6",
+    name: "Creating a new index on an existing table",
+    condition: "A new index was created on an existing table without the `CONCURRENTLY` keyword",
+    workaround: "Run `CREATE INDEX CONCURRENTLY` instead of `CREATE INDEX`",
+    effect: "This blocks all writes to the table while the index is being created",
+};
+pub const NEW_UNIQUE_CONSTRAINT_CREATED_INDEX: StaticHintData = StaticHintData {
+    id: "E7",
+    name: "Creating a new unique constraint",
+    condition: "Found a new unique constraint and a new index",
+    workaround: "`CREATE UNIQUE INDEX CONCURRENTLY`, then add the constraint using the index",
+    effect: "This blocks all writes to the table while the index is being created and validated",
+};
+pub const NEW_EXCLUSION_CONSTRAINT_FOUND: StaticHintData = StaticHintData {
+    id: "E8",
+    name: "Creating a new exclusion constraint",
+    condition: "Found a new exclusion constraint",
+    workaround: "There is no safe way to add an exclusion constraint to an existing table",
+    effect:
+        "This blocks all reads and writes to the table while the constraint index is being created",
+};
+pub const TOOK_DANGEROUS_LOCK_WITHOUT_TIMEOUT: StaticHintData = StaticHintData {
+    id: "E9",
+    name: "Taking dangerous lock without timeout",
+    condition: "A lock that would block many common operations was taken without a timeout",
+    workaround: "Run `SET LOCAL lock_timeout = '2s';` before the statement and retry the migration if necessary",
+    effect: "This can block all other operations on the table indefinitely if any other transaction \
+    holds a conflicting lock while `idle in transaction` or `active`",
+
+};
+pub const REWROTE_TABLE_WHILE_HOLDING_DANGEROUS_LOCK: StaticHintData = StaticHintData {
+    id: "E10",
+    name: "Rewrote table or index while holding dangerous lock",
+    condition: "A table or index was rewritten while holding a lock that blocks many operations",
+    workaround: "Build a new table or index, write to both, then swap them",
+    effect: "This blocks many operations on the table or index while the rewrite is in progress",
+};

--- a/src/hints.rs
+++ b/src/hints.rs
@@ -1,3 +1,5 @@
+use crate::hint_data;
+use crate::hint_data::StaticHintData;
 use crate::output::output_format::Hint;
 use itertools::Itertools;
 use std::cmp::Reverse;
@@ -10,23 +12,37 @@ use crate::tracing::tracer::StatementCtx;
 type HintFn = fn(&StatementCtx) -> Option<String>;
 
 pub struct HintInfo {
-    pub(crate) code: &'static str,
-    pub(crate) name: &'static str,
-    pub(crate) condition: &'static str,
-    pub(crate) workaround: &'static str,
-    pub(crate) effect: &'static str,
+    meta: &'static StaticHintData,
     render_help: HintFn,
+}
+
+impl HintInfo {
+    pub fn code(&self) -> &'static str {
+        self.meta.id
+    }
+    pub fn name(&self) -> &'static str {
+        self.meta.name
+    }
+    pub fn condition(&self) -> &'static str {
+        self.meta.condition
+    }
+    pub fn workaround(&self) -> &'static str {
+        self.meta.workaround
+    }
+    pub fn effect(&self) -> &'static str {
+        self.meta.effect
+    }
 }
 
 impl HintInfo {
     pub(crate) fn check(&self, trace: &StatementCtx) -> Option<Hint> {
         (self.render_help)(trace).map(|help| {
             Hint::new(
-                self.code,
-                self.name,
-                self.condition,
-                self.effect,
-                self.workaround,
+                self.code(),
+                self.name(),
+                self.condition(),
+                self.effect(),
+                self.workaround(),
                 help,
             )
         })
@@ -261,98 +277,77 @@ fn rewrote_table_or_index(ctx: &StatementCtx) -> Option<String> {
     Some(help)
 }
 
-pub mod ids {
-    pub const VALIDATE_CONSTRAINT_WITH_LOCK: &str = "E1";
-    pub const MAKE_COLUMN_NOT_NULLABLE_WITH_LOCK: &str = "E2";
-    pub const ADD_JSON_COLUMN: &str = "E3";
-    pub const RUNNING_STATEMENT_WHILE_HOLDING_ACCESS_EXCLUSIVE: &str = "E4";
-    pub const TYPE_CHANGE_REQUIRES_TABLE_REWRITE: &str = "E5";
-    pub const NEW_INDEX_ON_EXISTING_TABLE_IS_NONCONCURRENT: &str = "E6";
-    pub const NEW_UNIQUE_CONSTRAINT_CREATED_INDEX: &str = "E7";
-    pub const NEW_EXCLUSION_CONSTRAINT_FOUND: &str = "E8";
-    pub const TOOK_DANGEROUS_LOCK_WITHOUT_TIMEOUT: &str = "E9";
-    pub const REWROTE_TABLE_WHILE_HOLDING_DANGEROUS_LOCK: &str = "E10";
-}
 /// All the hints eugene can check statement traces against
-pub const HINTS: [HintInfo; 10] = [
-    HintInfo {
-        name: "Validating table with a new constraint",
-        code: ids::VALIDATE_CONSTRAINT_WITH_LOCK,
-        condition: "A new constraint was added and it is already `VALID`",
-        workaround: "Add the constraint as `NOT VALID` and validate it with `ALTER TABLE ... VALIDATE CONSTRAINT` later",
-        effect: "This blocks all table access until all rows are validated",
-        render_help: add_new_valid_constraint_help,
-    },
-    HintInfo {
-        name: "Validating table with a new `NOT NULL` column",
-        code: ids::MAKE_COLUMN_NOT_NULLABLE_WITH_LOCK,
-        condition: "A column was changed from `NULL` to `NOT NULL`",
-        workaround: "Add a `CHECK` constraint as `NOT VALID`, validate it later, then make the column `NOT NULL`",
-        effect: "This blocks all table access until all rows are validated",
-        render_help: make_column_not_nullable_help,
-    },
-    HintInfo {
-        name: "Add a new JSON column",
-        code: ids::ADD_JSON_COLUMN,
-        condition: "A new column of type `json` was added to a table",
-        workaround: "Use the `jsonb` type instead, it supports all use-cases of `json` and is more robust and compact",
-        effect: "This breaks `SELECT DISTINCT` queries or other operations that need equality checks on the column",
-        render_help: add_json_column,
-    },
-    HintInfo {
-        name: "Running more statements after taking `AccessExclusiveLock`",
-        code: ids::RUNNING_STATEMENT_WHILE_HOLDING_ACCESS_EXCLUSIVE,
-        condition: "A transaction that holds an `AccessExclusiveLock` started a new statement",
-        workaround: "Run this statement in a new transaction",
-        effect: "This blocks all access to the table for the duration of this statement",
-        render_help: running_statement_while_holding_access_exclusive,
-    },
-    HintInfo {
-        name: "Type change requiring table rewrite",
-        code: ids::TYPE_CHANGE_REQUIRES_TABLE_REWRITE,
-        condition: "A column was changed to a data type that isn't binary compatible",
-        workaround: "Add a new column, update it in batches, and drop the old column",
-        effect: "This causes a full table rewrite while holding a lock that prevents all other use of the table",
-        render_help: type_change_requires_table_rewrite,
-    },
-    HintInfo {
-        name: "Creating a new index on an existing table",
-        code: ids::NEW_INDEX_ON_EXISTING_TABLE_IS_NONCONCURRENT,
-        condition: "A new index was created on an existing table without the `CONCURRENTLY` keyword",
-        workaround: "Run `CREATE INDEX CONCURRENTLY` instead of `CREATE INDEX`",
-        effect: "This blocks all writes to the table while the index is being created",
-        render_help: new_index_on_existing_table_is_nonconcurrent,
-    },
-    HintInfo {
-        name: "Creating a new unique constraint",
-        code: ids::NEW_UNIQUE_CONSTRAINT_CREATED_INDEX,
-        condition: "Found a new unique constraint and a new index",
-        workaround: "`CREATE UNIQUE INDEX CONCURRENTLY`, then add the constraint using the index",
-        effect: "This blocks all writes to the table while the index is being created and validated",
-        render_help: new_unique_constraint_created_index,
-    },
-    HintInfo {
-        name: "Creating a new exclusion constraint",
-        code: ids::NEW_EXCLUSION_CONSTRAINT_FOUND,
-        condition: "Found a new exclusion constraint",
-        workaround: "There is no safe way to add an exclusion constraint to an existing table",
-        effect: "This blocks all reads and writes to the table while the constraint index is being created",
-        render_help: new_exclusion_constraint_found,
-    },
-    HintInfo {
-        name: "Taking dangerous lock without timeout",
-        code: ids::TOOK_DANGEROUS_LOCK_WITHOUT_TIMEOUT,
-        condition: "A lock that would block many common operations was taken without a timeout",
-        workaround: "Run `SET LOCAL lock_timeout = '2s';` before the statement and retry the migration if necessary",
-        effect: "This can block all other operations on the table indefinitely if any other transaction holds a conflicting lock while `idle in transaction` or `active`",
-        render_help: took_dangerous_lock_without_timeout,
-    },
-    HintInfo {
-        name: "Rewrote table or index while holding dangerous lock",
-        code: ids::REWROTE_TABLE_WHILE_HOLDING_DANGEROUS_LOCK,
-        condition: "A table or index was rewritten while holding a lock that blocks many operations",
-        workaround: "Build a new table or index, write to both, then swap them",
-        effect: "This blocks many operations on the table or index while the rewrite is in progress",
-        render_help: rewrote_table_or_index,
-    }
+pub fn all_hints() -> &'static [HintInfo] {
+    HINTS
+}
+
+/// Run all hints against a statement trace and return the ones that apply
+pub fn run_hints<'a>(trace: &'a StatementCtx) -> impl Iterator<Item = Hint> + 'a {
+    HINTS.iter().filter_map(|hint| hint.check(trace))
+}
+pub const VALIDATE_CONSTRAINT_WITH_LOCK: HintInfo = HintInfo {
+    meta: &hint_data::VALIDATE_CONSTRAINT_WITH_LOCK,
+    render_help: add_new_valid_constraint_help,
+};
+pub const MAKE_COLUMN_NOT_NULLABLE_WITH_LOCK: HintInfo = HintInfo {
+    meta: &hint_data::MAKE_COLUMN_NOT_NULLABLE_WITH_LOCK,
+    render_help: make_column_not_nullable_help,
+};
+pub const ADD_JSON_COLUMN: HintInfo = HintInfo {
+    meta: &hint_data::ADD_JSON_COLUMN,
+    render_help: add_json_column,
+};
+pub const RUNNING_STATEMENT_WHILE_HOLDING_ACCESS_EXCLUSIVE: HintInfo = HintInfo {
+    meta: &hint_data::RUNNING_STATEMENT_WHILE_HOLDING_ACCESS_EXCLUSIVE,
+    render_help: running_statement_while_holding_access_exclusive,
+};
+pub const TYPE_CHANGE_REQUIRES_TABLE_REWRITE: HintInfo = HintInfo {
+    meta: &hint_data::TYPE_CHANGE_REQUIRES_TABLE_REWRITE,
+    render_help: type_change_requires_table_rewrite,
+};
+pub const NEW_INDEX_ON_EXISTING_TABLE_IS_NONCONCURRENT: HintInfo = HintInfo {
+    meta: &hint_data::NEW_INDEX_ON_EXISTING_TABLE_IS_NONCONCURRENT,
+    render_help: new_index_on_existing_table_is_nonconcurrent,
+};
+pub const NEW_UNIQUE_CONSTRAINT_CREATED_INDEX: HintInfo = HintInfo {
+    meta: &hint_data::NEW_UNIQUE_CONSTRAINT_CREATED_INDEX,
+    render_help: new_unique_constraint_created_index,
+};
+pub const NEW_EXCLUSION_CONSTRAINT_FOUND: HintInfo = HintInfo {
+    meta: &hint_data::NEW_EXCLUSION_CONSTRAINT_FOUND,
+    render_help: new_exclusion_constraint_found,
+};
+pub const TOOK_DANGEROUS_LOCK_WITHOUT_TIMEOUT: HintInfo = HintInfo {
+    meta: &hint_data::TOOK_DANGEROUS_LOCK_WITHOUT_TIMEOUT,
+    render_help: took_dangerous_lock_without_timeout,
+};
+pub const REWROTE_TABLE_WHILE_HOLDING_DANGEROUS_LOCK: HintInfo = HintInfo {
+    meta: &hint_data::REWROTE_TABLE_WHILE_HOLDING_DANGEROUS_LOCK,
+    render_help: rewrote_table_or_index,
+};
+
+/// All the hints eugene can check statement traces against
+const HINTS: &[HintInfo] = &[
+    VALIDATE_CONSTRAINT_WITH_LOCK,
+    MAKE_COLUMN_NOT_NULLABLE_WITH_LOCK,
+    ADD_JSON_COLUMN,
+    RUNNING_STATEMENT_WHILE_HOLDING_ACCESS_EXCLUSIVE,
+    TYPE_CHANGE_REQUIRES_TABLE_REWRITE,
+    NEW_INDEX_ON_EXISTING_TABLE_IS_NONCONCURRENT,
+    NEW_UNIQUE_CONSTRAINT_CREATED_INDEX,
+    NEW_EXCLUSION_CONSTRAINT_FOUND,
+    TOOK_DANGEROUS_LOCK_WITHOUT_TIMEOUT,
+    REWROTE_TABLE_WHILE_HOLDING_DANGEROUS_LOCK,
 ];
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_no_duplicated_ids() {
+        let ids: HashSet<_> = super::all_hints().iter().map(|hint| hint.meta.id).collect();
+        assert_eq!(ids.len(), super::all_hints().len());
+    }
+}

--- a/src/hints.rs
+++ b/src/hints.rs
@@ -134,9 +134,9 @@ fn type_change_requires_table_rewrite(sql_statement_trace: &StatementCtx) -> Opt
         .find(|obj| obj.rel_kind == RelKind::Table)?;
 
     let help = format!(
-            "The column `{}` in the table `{}.{}` was changed from type `{}` to `{}`. This always requires \
-            an `AccessExclusiveLock` that will block all other transactions from using the table, and for some \
-            type changes, it causes a time-consuming table rewrite.",
+            "The column `{}` in the table `{}.{}` was changed from type `{}` to `{}`. This requires \
+            an `AccessExclusiveLock` that will block all other transactions from using the table while \
+            it is being rewritten.",
             column.new.column_name,
             column.new.schema_name,
             column.new.table_name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ use crate::tracing::TxLockTracer;
 
 /// Hints that can help avoid dangerous migrations, by minimizing time spent holding dangerous locks.
 pub mod hints;
+/// Hints that can be trigged only by looking at the SQL script, without running it.
+pub mod lints;
 /// Generate output structures for lock traces and static data like lock modes.
 /// This module is used by the binary to generate output in various formats is currently
 /// the best documentation of output format, and can be considered a public api

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ use tracing::trace_transaction;
 use crate::sqltext::{read_sql_statements, resolve_placeholders, sql_statements};
 use crate::tracing::TxLockTracer;
 
+/// Static data for hints and lints, used to identify them in output or input.
+pub mod hint_data;
 /// Hints that can help avoid dangerous migrations, by minimizing time spent holding dangerous locks.
 pub mod hints;
 /// Hints that can be trigged only by looking at the SQL script, without running it.

--- a/src/lints.rs
+++ b/src/lints.rs
@@ -1,0 +1,126 @@
+pub use crate::lints::ast::StatementSummary;
+
+/// The `ast` module provides a way to describe a parsed SQL statement in a structured way,
+/// using simpler trees than the ones provided by `pg_query`.
+pub mod ast;
+
+/// Represents mutable state for linting through a single SQL script.
+///
+/// This struct is used to keep track of new objects, so the lint rules can check
+/// visibility to other transactions, usage of lock timeouts and other properties
+/// that require state to be kept between different statements.
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct LintContext {
+    locktimeout: bool,
+    created_objects: Vec<(String, String)>,
+}
+
+impl LintContext {
+    /// Query if the script under linting has previously created an object with the given schema and name.
+    pub fn has_created_object(&self, schema: &str, name: &str) -> bool {
+        self.created_objects
+            .iter()
+            .any(|(s, n)| schema.eq_ignore_ascii_case(s) && name.eq_ignore_ascii_case(n))
+    }
+    /// Query if the script under linting has previously set a lock timeout.
+    pub fn has_locktimeout(&self) -> bool {
+        self.locktimeout
+    }
+    /// Update the context with the information from a new statement.
+    pub fn update_from(&mut self, summary: &StatementSummary) {
+        if let StatementSummary::LockTimeout = summary {
+            self.locktimeout = true;
+        }
+        summary.created_objects().iter().for_each(|(schema, name)| {
+            self.created_objects
+                .push((schema.to_string(), name.to_string()))
+        });
+    }
+}
+
+/// Emit a warning if a statement takes a lock that is visible to other transactions without a timeout
+pub fn emit_locktimeout_warning(ctx: &LintContext, summary: &StatementSummary) -> bool {
+    let takes_lock = matches!(
+        summary,
+        StatementSummary::AlterTable { .. }
+            | StatementSummary::CreateIndex {
+                concurrently: false,
+                ..
+            }
+    );
+    let lock_visible_outside_tx = summary
+        .lock_targets()
+        .iter()
+        .any(|(schema, name)| !ctx.has_created_object(schema, name));
+    takes_lock && lock_visible_outside_tx && !ctx.has_locktimeout()
+}
+
+/// Summarize a SQL script into a list of `StatementSummary` trees.
+pub fn summarize<S: AsRef<str>>(sql: S) -> anyhow::Result<Vec<StatementSummary>> {
+    let statements = pg_query::split_with_parser(sql.as_ref())?;
+    let mut parsed = Vec::new();
+    for statement in statements {
+        let tree = pg_query::parse(statement)?;
+        for raw in tree.protobuf.stmts.iter() {
+            if let Some(node) = &raw.stmt {
+                if let Some(node_ref) = &node.node {
+                    parsed.push(ast::describe(&node_ref.to_ref())?);
+                }
+            }
+        }
+    }
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lints::StatementSummary;
+
+    #[test]
+    fn test_lock_timeout_visibility_rule() {
+        let mut ctx = LintContext::default();
+        let create = StatementSummary::CreateIndex {
+            concurrently: false,
+            schema: "public".to_string(),
+            target: "books".to_string(),
+            idxname: "books_title_idx".to_string(),
+        };
+        // Locks table
+        assert!(emit_locktimeout_warning(&ctx, &create));
+        ctx.update_from(&StatementSummary::CreateTable {
+            schema: "public".to_string(),
+            name: "books".to_string(),
+        });
+        // Locks index
+        assert!(emit_locktimeout_warning(&ctx, &create));
+        ctx.update_from(&create);
+        // No locktimeout, but only lock objects visible to this tx
+        assert!(!emit_locktimeout_warning(&ctx, &create));
+    }
+    #[test]
+    fn test_lock_timeout_with_locktimeout() {
+        let mut ctx = LintContext::default();
+        let create = StatementSummary::CreateIndex {
+            concurrently: false,
+            schema: "public".to_string(),
+            target: "books".to_string(),
+            idxname: "books_title_idx".to_string(),
+        };
+        // Locks table
+        assert!(emit_locktimeout_warning(&ctx, &create));
+        ctx.update_from(&StatementSummary::LockTimeout);
+        // Locktimeout, no warning
+        assert!(!emit_locktimeout_warning(&ctx, &create));
+    }
+
+    #[test]
+    fn test_locktimeout_without_taking_lock() {
+        let ctx: LintContext = LintContext::default();
+        let create_table = StatementSummary::CreateTable {
+            schema: "public".to_string(),
+            name: "books".to_string(),
+        };
+        assert!(!emit_locktimeout_warning(&ctx, &create_table));
+    }
+}

--- a/src/lints/rules.rs
+++ b/src/lints/rules.rs
@@ -1,0 +1,352 @@
+use pg_query::protobuf::ConstrType;
+
+use crate::hint_data::StaticHintData;
+use crate::lints::ast::AlterTableAction;
+use crate::lints::{LintedStatement, StatementSummary};
+use crate::output::output_format::Hint;
+
+pub struct LintRule {
+    meta: &'static StaticHintData,
+    check: fn(LintedStatement) -> Option<String>,
+}
+
+impl LintRule {
+    pub fn id(&self) -> &'static str {
+        self.meta.id
+    }
+    pub fn name(&self) -> &'static str {
+        self.meta.name
+    }
+    pub fn workaround(&self) -> &'static str {
+        self.meta.workaround
+    }
+    pub fn effect(&self) -> &'static str {
+        self.meta.effect
+    }
+    pub fn condition(&self) -> &'static str {
+        self.meta.condition
+    }
+    pub fn check(&self, stmt: LintedStatement) -> Option<Hint> {
+        (self.check)(stmt).map(|help| Hint {
+            id: self.id().to_string(),
+            name: self.name().to_string(),
+            effect: self.effect().to_string(),
+            workaround: self.workaround().to_string(),
+            condition: self.condition().to_string(),
+            help,
+        })
+    }
+}
+
+/// Emit a warning if a statement takes a lock that is visible to other transactions without a timeout
+pub fn locktimeout_warning(stmt: LintedStatement) -> Option<String> {
+    let target = stmt
+        .locks_visible_outside_tx()
+        .into_iter()
+        .find(|(schema, name)| stmt.takes_lock(schema, name));
+    match target {
+        Some((schema, name)) if !stmt.has_lock_timeout() => Some(format!(
+            "Statement takes lock on `{}.{}`, but does not set a lock timeout",
+            if schema.is_empty() { "public" } else { schema },
+            name
+        )),
+        _ => None,
+    }
+}
+
+pub const LOCKTIMEOUT_WARNING: LintRule = LintRule {
+    meta: &crate::hint_data::TOOK_DANGEROUS_LOCK_WITHOUT_TIMEOUT,
+    check: locktimeout_warning,
+};
+
+fn create_index_nonconcurrently(stmt: LintedStatement) -> Option<String> {
+    match stmt.statement {
+        StatementSummary::CreateIndex {
+            schema,
+            idxname,
+            target,
+            concurrently: false,
+            ..
+        } if stmt.is_visible(schema, target) => {
+            let schema = if schema.is_empty() { "public" } else { schema };
+            Some(format!("Statement takes `ShareLock` on `{schema}.{target}`, blocking writes while creating index `{schema}.{idxname}`"))
+        }
+        _ => None,
+    }
+}
+
+/// `CREATE INDEX` without `CONCURRENTLY`
+pub const CREATE_INDEX_NONCONCURRENTLY: LintRule = LintRule {
+    meta: &crate::hint_data::NEW_INDEX_ON_EXISTING_TABLE_IS_NONCONCURRENT,
+    check: create_index_nonconcurrently,
+};
+
+fn adding_valid_constraint(stmt: LintedStatement) -> Option<String> {
+    fn is_valid_constraint(alter_table_cmd: &AlterTableAction) -> bool {
+        matches!(
+            alter_table_cmd,
+            AlterTableAction::AddConstraint {
+                valid: true,
+                constraint_type: ConstrType::ConstrCheck
+                    | ConstrType::ConstrNotnull
+                    | ConstrType::ConstrForeign,
+                ..
+            }
+        )
+    }
+    match stmt.statement {
+        StatementSummary::AlterTable {
+            schema,
+            name,
+            actions,
+            ..
+        } if stmt.is_visible(schema, name) => {
+            let schema = if schema.is_empty() { "public" } else { schema };
+            let new_constraint = actions.iter().find(|cmd| is_valid_constraint(cmd));
+            let table = name;
+            if let Some(AlterTableAction::AddConstraint {
+                name,
+                constraint_type: _,
+                ..
+            }) = new_constraint
+            {
+                let name = if name.is_empty() {
+                    String::new()
+                } else {
+                    format!("`{name}` ")
+                };
+                Some(format!(
+                    "Statement takes `AccessExclusiveLock` on `{schema}.{table}`, \
+                blocking reads until constraint {name}is validated"
+                ))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+/// Adding a constraint without using `NOT VALID`
+pub const ADDING_VALID_CONSTRAINT: LintRule = LintRule {
+    meta: &crate::hint_data::VALIDATE_CONSTRAINT_WITH_LOCK,
+    check: adding_valid_constraint,
+};
+
+fn adding_exclusion_constraint(stmt: LintedStatement) -> Option<String> {
+    match stmt.statement {
+        StatementSummary::AlterTable {
+            schema,
+            name,
+            actions,
+            ..
+        } if stmt.is_visible(schema, name) => {
+            let new_constraint = actions.iter().find(|cmd| {
+                matches!(
+                    cmd,
+                    AlterTableAction::AddConstraint {
+                        constraint_type: ConstrType::ConstrExclusion,
+                        ..
+                    }
+                )
+            });
+            let table = name;
+            if let Some(AlterTableAction::AddConstraint {
+                name,
+                constraint_type: _,
+                ..
+            }) = new_constraint
+            {
+                let schema = if schema.is_empty() { "public" } else { schema };
+                Some(format!("Statement takes `AccessExclusiveLock` on `{schema}.{table}`, blocking reads and writes until constraint `{name}` is validated and has created index"))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Adding a new exclusion constraint
+pub const ADDING_EXCLUSION_CONSTRAINT: LintRule = LintRule {
+    meta: &crate::hint_data::NEW_EXCLUSION_CONSTRAINT_FOUND,
+    check: adding_exclusion_constraint,
+};
+
+fn add_new_unique_constraint_without_using_index(stmt: LintedStatement) -> Option<String> {
+    match stmt.statement {
+        StatementSummary::AlterTable {
+            schema,
+            name,
+            actions,
+            ..
+        } if stmt.is_visible(schema, name) => {
+            let schema = if schema.is_empty() { "public" } else { schema };
+            let table = name;
+            if let Some(AlterTableAction::AddConstraint {
+                name,
+                use_index: false,
+                ..
+            }) = actions.iter().find(|cmd| {
+                matches!(
+                    cmd,
+                    AlterTableAction::AddConstraint {
+                        constraint_type: ConstrType::ConstrUnique | ConstrType::ConstrPrimary,
+                        ..
+                    }
+                )
+            }) {
+                Some(format!(
+                    "New constraint {name} creates implicit index on `{schema}.{table}`, \
+                blocking writes until index is created and validated"
+                ))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Letting `add constraint ... unique` create an index using a `ShareLock`
+pub const ADD_NEW_UNIQUE_CONSTRAINT_WITHOUT_USING_INDEX: LintRule = LintRule {
+    meta: &crate::hint_data::NEW_UNIQUE_CONSTRAINT_CREATED_INDEX,
+    check: add_new_unique_constraint_without_using_index,
+};
+
+fn run_more_statements_after_taking_access_exclusive(stmt: LintedStatement) -> Option<String> {
+    if stmt.holding_access_exclusive() {
+        Some("Running more statements after taking `AccessExclusiveLock`".to_string())
+    } else {
+        None
+    }
+}
+
+pub const RUNNING_STATEMENT_WHILE_HOLDING_ACCESS_EXCLUSIVE: LintRule = LintRule {
+    meta: &crate::hint_data::RUNNING_STATEMENT_WHILE_HOLDING_ACCESS_EXCLUSIVE,
+    check: run_more_statements_after_taking_access_exclusive,
+};
+
+fn sets_column_to_not_null(stmt: LintedStatement) -> Option<String> {
+    match stmt.statement {
+        StatementSummary::AlterTable {
+            schema,
+            name,
+            actions,
+            ..
+        } if stmt.is_visible(schema, name) => {
+            let schema = if schema.is_empty() { "public" } else { schema };
+            let table = name;
+            actions
+                .iter()
+                .filter_map(|cmd| match cmd {
+                    AlterTableAction::SetNotNull { column } => Some(column),
+                    _ => None,
+                })
+                .map(|col_name| {
+                    format!(
+                        "Statement takes `AccessExclusiveLock` on `{schema}.{table}` by setting \
+                     `{col_name}` to `NOT NULL` blocking reads until all rows are validated"
+                    )
+                })
+                .next()
+        }
+        _ => None,
+    }
+}
+
+pub const MAKE_COLUMN_NOT_NULLABLE_WITH_LOCK: LintRule = LintRule {
+    meta: &crate::hint_data::MAKE_COLUMN_NOT_NULLABLE_WITH_LOCK,
+    check: sets_column_to_not_null,
+};
+
+fn sets_column_type_to_json(stmt: LintedStatement) -> Option<String> {
+    match stmt.statement {
+        // TODO: Create table also
+        StatementSummary::AlterTable {
+            schema,
+            name,
+            actions,
+        } => {
+            let added_json = actions
+                .iter()
+                .filter_map(|cmd| match cmd {
+                    AlterTableAction::SetType { type_name, column }
+                    | AlterTableAction::AddColumn { type_name, column }
+                        if type_name == "json" =>
+                    {
+                        Some(column)
+                    }
+                    _ => None,
+                })
+                .next();
+            added_json.map(|column| format!(
+                    "Set type of column `{column}` to `json` in `{schema}.{name}`. \
+                    The `json` type does not support equality and should not be used, use `jsonb` instead"))
+        }
+        _ => None,
+    }
+}
+
+pub const SET_COLUMN_TYPE_TO_JSON: LintRule = LintRule {
+    meta: &crate::hint_data::ADD_JSON_COLUMN,
+    check: sets_column_type_to_json,
+};
+
+fn changes_type_of_column_in_visible_object(stmt: LintedStatement) -> Option<String> {
+    match stmt.statement {
+        StatementSummary::AlterTable {
+            schema,
+            name,
+            actions,
+        } if stmt.is_visible(schema, name) => {
+            let changed_column = actions
+                .iter()
+                .filter_map(|cmd| match cmd {
+                    AlterTableAction::SetType { column, type_name } => Some((column, type_name)),
+                    _ => None,
+                })
+                .next();
+            changed_column.map(|(column, type_name)| {
+                format!(
+                    "Changed type of column `{column}` to `{type_name}` in `{schema}.{name}`. \
+                    This operation requires a full table rewrite with `AccessExclusiveLock` if `{type_name}` is not binary compatible with \
+                    the previous type of `{column}`. Prefer adding a new column with the new type, then dropping/renaming."
+                )
+            })
+        }
+        _ => None,
+    }
+}
+
+pub const CHANGE_COLUMN_TYPE: LintRule = LintRule {
+    meta: &crate::hint_data::TYPE_CHANGE_REQUIRES_TABLE_REWRITE,
+    check: changes_type_of_column_in_visible_object,
+};
+
+const RULES: &[LintRule] = &[
+    LOCKTIMEOUT_WARNING,
+    CREATE_INDEX_NONCONCURRENTLY,
+    ADDING_VALID_CONSTRAINT,
+    ADDING_EXCLUSION_CONSTRAINT,
+    ADD_NEW_UNIQUE_CONSTRAINT_WITHOUT_USING_INDEX,
+    RUNNING_STATEMENT_WHILE_HOLDING_ACCESS_EXCLUSIVE,
+    MAKE_COLUMN_NOT_NULLABLE_WITH_LOCK,
+    SET_COLUMN_TYPE_TO_JSON,
+    CHANGE_COLUMN_TYPE,
+];
+
+/// Get all available lint rules
+pub fn all_rules() -> impl Iterator<Item = &'static LintRule> {
+    RULES.iter()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_no_duplicated_ids() {
+        let ids: HashSet<_> = super::all_rules().map(|rule| rule.id()).collect();
+        assert_eq!(ids.len(), super::all_rules().count());
+    }
+}

--- a/src/output.rs
+++ b/src/output.rs
@@ -3,12 +3,11 @@ use serde::Serialize;
 
 use output_format::Hint;
 pub use output_format::{
-    Column, Constraint, FullSqlStatementLockTrace, FullTraceData, ModifiedColumn,
-    ModifiedConstraint, TracedLock,
+    Column, Constraint, DbObject, FullSqlStatementLockTrace, FullTraceData, GenericHint, Lint,
+    LintReport, ModifiedColumn, ModifiedConstraint, TracedLock,
 };
 
 use crate::output::markdown_helpers::{theader, trow};
-use crate::output::output_format::DbObject;
 use crate::pg_types::lock_modes::LockMode;
 use crate::pg_types::locks::Lock;
 use crate::tracing::{SqlStatementTrace, TxLockTracer};

--- a/src/output/output_format.rs
+++ b/src/output/output_format.rs
@@ -12,16 +12,18 @@ pub struct GenericHint {
     pub condition: String,
     pub effect: String,
     pub workaround: String,
+    pub has_lint: bool,
 }
 
 impl From<&HintInfo> for GenericHint {
     fn from(value: &HintInfo) -> Self {
         GenericHint {
-            id: value.code.to_string(),
-            name: value.name.to_string(),
-            condition: value.condition.to_string(),
-            effect: value.effect.to_string(),
-            workaround: value.workaround.to_string(),
+            id: value.code().to_string(),
+            name: value.name().to_string(),
+            condition: value.condition().to_string(),
+            effect: value.effect().to_string(),
+            workaround: value.workaround().to_string(),
+            has_lint: crate::lints::rules::all_rules().any(|rule| rule.id() == value.code()),
         }
     }
 }
@@ -216,4 +218,16 @@ impl Hint {
             help: help.to_string(),
         }
     }
+}
+
+#[derive(Debug, Serialize, Clone, Eq, PartialEq)]
+pub struct Lint {
+    pub statement_number: usize,
+    pub sql: String,
+    pub lints: Vec<Hint>,
+}
+
+#[derive(Debug, Serialize, Clone, Eq, PartialEq)]
+pub struct LintReport {
+    pub lints: Vec<Lint>,
 }

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -34,7 +34,7 @@ mod tests {
     use postgres::{Client, NoTls};
 
     use crate::generate_new_test_db;
-    use crate::hints::ids;
+    use crate::hint_data;
     use crate::pg_types::contype::Contype;
     use crate::pg_types::lock_modes::LockMode;
 
@@ -62,7 +62,7 @@ mod tests {
         assert!(!modification.new.nullable);
         assert!(trace.triggered_hints[0]
             .iter()
-            .any(|hint| hint.id == ids::MAKE_COLUMN_NOT_NULLABLE_WITH_LOCK));
+            .any(|hint| hint.id == hint_data::MAKE_COLUMN_NOT_NULLABLE_WITH_LOCK.id));
     }
 
     #[test]
@@ -104,10 +104,10 @@ mod tests {
         );
         assert!(trace.triggered_hints[2]
             .iter()
-            .any(|hint| hint.id == ids::VALIDATE_CONSTRAINT_WITH_LOCK));
+            .any(|hint| hint.id == hint_data::VALIDATE_CONSTRAINT_WITH_LOCK.id));
         assert!(trace.triggered_hints[2]
             .iter()
-            .any(|hint| hint.id == ids::TOOK_DANGEROUS_LOCK_WITHOUT_TIMEOUT));
+            .any(|hint| hint.id == hint_data::TOOK_DANGEROUS_LOCK_WITHOUT_TIMEOUT.id));
     }
 
     #[test]
@@ -126,7 +126,7 @@ mod tests {
         assert!(!constraint.valid);
         assert!(!trace.triggered_hints[0]
             .iter()
-            .any(|hint| hint.id == ids::VALIDATE_CONSTRAINT_WITH_LOCK));
+            .any(|hint| hint.id == hint_data::VALIDATE_CONSTRAINT_WITH_LOCK.id));
     }
 
     #[test]
@@ -160,10 +160,10 @@ mod tests {
         assert_eq!(modification.new.max_len.unwrap(), 255);
         assert!(trace.triggered_hints[0]
             .iter()
-            .any(|hint| hint.id == ids::TOOK_DANGEROUS_LOCK_WITHOUT_TIMEOUT));
+            .any(|hint| hint.id == hint_data::TOOK_DANGEROUS_LOCK_WITHOUT_TIMEOUT.id));
         assert!(trace.triggered_hints[0]
             .iter()
-            .any(|hint| hint.id == ids::TYPE_CHANGE_REQUIRES_TABLE_REWRITE));
+            .any(|hint| hint.id == hint_data::TYPE_CHANGE_REQUIRES_TABLE_REWRITE.id));
     }
 
     #[test]
@@ -237,10 +237,10 @@ mod tests {
             .any(|obj| obj.object_name == "books_title_idx"));
         assert!(trace.triggered_hints[0]
             .iter()
-            .any(|hint| hint.id == ids::NEW_INDEX_ON_EXISTING_TABLE_IS_NONCONCURRENT));
+            .any(|hint| hint.id == hint_data::NEW_INDEX_ON_EXISTING_TABLE_IS_NONCONCURRENT.id));
         assert!(trace.triggered_hints[0]
             .iter()
-            .any(|hint| hint.id == ids::TOOK_DANGEROUS_LOCK_WITHOUT_TIMEOUT));
+            .any(|hint| hint.id == hint_data::TOOK_DANGEROUS_LOCK_WITHOUT_TIMEOUT.id));
     }
 
     #[test]
@@ -279,7 +279,7 @@ mod tests {
         assert!(trace.statements[0].created_objects.is_empty());
         assert!(trace.triggered_hints[0]
             .iter()
-            .any(|hint| hint.id == ids::TOOK_DANGEROUS_LOCK_WITHOUT_TIMEOUT));
+            .any(|hint| hint.id == hint_data::TOOK_DANGEROUS_LOCK_WITHOUT_TIMEOUT.id));
     }
 
     #[test]
@@ -315,7 +315,7 @@ mod tests {
         assert_eq!(modification.typename, "json");
         assert!(trace.triggered_hints[0]
             .iter()
-            .any(|hint| hint.id == ids::ADD_JSON_COLUMN));
+            .any(|hint| hint.id == hint_data::ADD_JSON_COLUMN.id));
     }
 
     #[test]
@@ -339,7 +339,7 @@ mod tests {
         assert!(!modification.new.nullable);
         assert!(!trace.triggered_hints[0]
             .iter()
-            .any(|hint| hint.id == ids::MAKE_COLUMN_NOT_NULLABLE_WITH_LOCK));
+            .any(|hint| hint.id == hint_data::MAKE_COLUMN_NOT_NULLABLE_WITH_LOCK.id));
     }
 
     #[test]

--- a/src/tracing/tracer.rs
+++ b/src/tracing/tracer.rs
@@ -83,7 +83,7 @@ pub struct TxLockTracer {
     pub(crate) relfile_ids: HashMap<Oid, u32>,
 }
 
-pub(crate) struct StatementCtx<'a> {
+pub struct StatementCtx<'a> {
     pub(crate) sql_statement_trace: &'a SqlStatementTrace,
     pub(crate) transaction: &'a TxLockTracer,
 }
@@ -211,7 +211,7 @@ impl TxLockTracer {
             sql_statement_trace: &statement,
             transaction: self,
         };
-        let hints: Vec<_> = hints::HINTS.iter().filter_map(|h| h.check(&ctx)).collect();
+        let hints: Vec<_> = hints::run_hints(&ctx).collect();
         self.triggered_hints.push(hints);
         self.statements.push(statement);
         self.all_locks.extend(locks_taken.iter().cloned());


### PR DESCRIPTION
First stab at #37, expecting to add a frontend/middle layer for this later this week. This recognizes:

- `SET [LOCAL] lock_timeout = ...`
- `ALTER TABLE ...` -- but doesn't recognize most variants yet
  + Setting new type
  + Setting to not null
- `CREATE INDEX [CONCURRENTLY]`
- `CREATE TABLE`
- `CREATE TABLE AS`

It gives us the tools to build the MVP lints:

- Locking a relation visible to other transactions without lock timeout
- Creating an index nonconcurrently
  + Although only directly, implicit indexes from adding primary key, unique constraint etc not picked up yet
- Setting a column to not null
