### PR TITLE
Exit with failure code if lints/hints trigger

### DIFF
--- a/src/tracing/tracer.rs
+++ b/src/tracing/tracer.rs
@@ -129,6 +129,10 @@ impl<'a> StatementCtx<'a> {
 }
 
 impl<'a> TxLockTracer<'a> {
+    /// True if no hints were triggered
+    pub fn success(&self) -> bool {
+        self.triggered_hints.iter().all(|hints| hints.is_empty())
+    }
     /// Trace a single SQL statement, recording the locks taken and the duration of the statement.
     pub fn trace_sql_statement(&mut self, tx: &mut Transaction, sql: &str) -> Result<()> {
         // TODO: This is too big and should be refactored into more manageable pieces


### PR DESCRIPTION
Add `-a | --accept-failures` to exit successfully regardless.

This solves #8 -- we fail by default, but combined with `--ignore` and `-- eugene: ignore` comments, we give some control of whether to report success or not.