### PR TITLE
Add lint for rewrites caused by adding serial or generated stored

### DIFF
--- a/src/bin/eugene.rs
+++ b/src/bin/eugene.rs
@@ -53,7 +53,7 @@ enum Commands {
         #[arg(short = 'i', long = "ignore")]
         ignored_hints: Vec<String>,
         /// Output format, plain, json or markdown
-        #[arg(short = 'f', long = "format", default_value = "json")]
+        #[arg(short = 'f', long = "format", default_value = "json", value_parser=clap::builder::PossibleValuesParser::new(["json", "markdown", "md"]))]
         format: String,
         /// Exit successfully even if problems are detected. Will still fail for invalid SQL.
         #[arg(short = 'a', long = "accept-failures", default_value_t = false)]
@@ -89,7 +89,7 @@ enum Commands {
         #[arg(short = 's', long = "skip-summary", default_value_t = false)]
         skip_summary: bool,
         /// Output format, plain, json or markdown
-        #[arg(short = 'f', long = "format", default_value = "json")]
+        #[arg(short = 'f', long = "format", default_value = "json", value_parser=clap::builder::PossibleValuesParser::new(["json", "markdown", "md", "plain"]))]
         format: String,
         /// Ignore the hints with these IDs, use `eugene hints` to see available hints. Can be used multiple times.
         ///

--- a/src/hint_data.rs
+++ b/src/hint_data.rs
@@ -89,3 +89,10 @@ pub const REWROTE_TABLE_WHILE_HOLDING_DANGEROUS_LOCK: StaticHintData = StaticHin
     workaround: "Build a new table or index, write to both, then swap them",
     effect: "This blocks many operations on the table or index while the rewrite is in progress",
 };
+pub const ADDED_SERIAL_OR_STORED_GENERATED_COLUMN: StaticHintData = StaticHintData {
+    id: "E11",
+    name: "Adding a `SERIAL` or `GENERATED ... STORED` column",
+    condition: "A new column was added with a `SERIAL` or `GENERATED` type",
+    workaround: "Can not be done without a table rewrite",
+    effect: "This blocks all table access until the table is rewritten",
+};


### PR DESCRIPTION
Adding a `serial`, `bigserial` or `generated always as (...) stored;` column causes a table rewrite while holding `AccessExclusiveLock`.