### PR TITLE
Add lint for altering the same table again

### DIFF
--- a/examples/add_authors_lints.md
+++ b/examples/add_authors_lints.md
@@ -66,6 +66,14 @@ A lock that would block many common operations was taken without a timeout. This
 
 Statement takes lock on `public.books`, but does not set a lock timeout
 
+#### Multiple `ALTER TABLE` statements where one will do
+
+ID: `W12`
+
+Multiple `ALTER TABLE` statements targets the same table. If the statements require table scans, there will be more scans than necessary. A safer way is: Combine the statements into one, separating the action with commas.
+
+Multiple `ALTER TABLE` statements on `public.books`. Combine them into a single statement to avoid scanning the table multiple times.
+
 ## Statement number 4
 
 ### SQL
@@ -99,6 +107,14 @@ ID: `E9`
 A lock that would block many common operations was taken without a timeout. This can block all other operations on the table indefinitely if any other transaction holds a conflicting lock while `idle in transaction` or `active`. A safer way is: Run `SET LOCAL lock_timeout = '2s';` before the statement and retry the migration if necessary.
 
 Statement takes lock on `public.books`, but does not set a lock timeout
+
+#### Multiple `ALTER TABLE` statements where one will do
+
+ID: `W12`
+
+Multiple `ALTER TABLE` statements targets the same table. If the statements require table scans, there will be more scans than necessary. A safer way is: Combine the statements into one, separating the action with commas.
+
+Multiple `ALTER TABLE` statements on `public.books`. Combine them into a single statement to avoid scanning the table multiple times.
 
 ## Statement number 5
 

--- a/examples/add_check_constraint.sql
+++ b/examples/add_check_constraint.sql
@@ -1,2 +1,5 @@
 alter table books add constraint check_title_not_null check (title is not null) not valid;
+-- eugene: ignore W12
+-- for this example, we're targeting the table twice to show the difference in locks
+-- and we can't do that if we add the constraint as valid to only alter the table once
 alter table books validate constraint check_title_not_null; -- this takes a different, lesser lock

--- a/examples/add_check_constraint_lints.md
+++ b/examples/add_check_constraint_lints.md
@@ -27,6 +27,9 @@ Statement takes lock on `public.books`, but does not set a lock timeout
 ### SQL
 
 ```sql
+-- eugene: ignore W12
+-- for this example, we're targeting the table twice to show the difference in locks
+-- and we can't do that if we add the constraint as valid to only alter the table once
 alter table books validate constraint check_title_not_null
 ```
 

--- a/examples/add_check_constraint_traced.md
+++ b/examples/add_check_constraint_traced.md
@@ -71,6 +71,9 @@ The statement took `AccessExclusiveLock` on the Table `public.books` without a t
 ### SQL
 
 ```sql
+-- eugene: ignore W12
+-- for this example, we're targeting the table twice to show the difference in locks
+-- and we can't do that if we add the constraint as valid to only alter the table once
 alter table books validate constraint check_title_not_null
 ```
 

--- a/examples/add_not_valid_fkey.sql
+++ b/examples/add_not_valid_fkey.sql
@@ -1,3 +1,6 @@
 create table authors(id serial primary key, name text);
 alter table books add column author_id integer null;
+-- eugene: ignore W12
+-- for this example, we're targeting the table twice to show the difference in locks
+-- and we can't do that if we add the constraint as valid to only alter the table on
 alter table books add constraint fk_books_authors foreign key (author_id) references authors(id) not valid;

--- a/examples/add_not_valid_fkey_lints.md
+++ b/examples/add_not_valid_fkey_lints.md
@@ -37,6 +37,9 @@ Statement takes lock on `public.books`, but does not set a lock timeout
 ### SQL
 
 ```sql
+-- eugene: ignore W12
+-- for this example, we're targeting the table twice to show the difference in locks
+-- and we can't do that if we add the constraint as valid to only alter the table on
 alter table books add constraint fk_books_authors foreign key (author_id) references authors(id) not valid
 ```
 

--- a/examples/add_not_valid_fkey_traced.md
+++ b/examples/add_not_valid_fkey_traced.md
@@ -94,6 +94,9 @@ The statement took `AccessExclusiveLock` on the Table `public.books` without a t
 ### SQL
 
 ```sql
+-- eugene: ignore W12
+-- for this example, we're targeting the table twice to show the difference in locks
+-- and we can't do that if we add the constraint as valid to only alter the table on
 alter table books add constraint fk_books_authors foreign key (author_id) references authors(id) not valid
 ```
 

--- a/examples/alter_column_not_null.sql
+++ b/examples/alter_column_not_null.sql
@@ -1,2 +1,1 @@
-alter table books alter column title set not null;
-alter table books add constraint title_unique unique (title);
+alter table books alter column title set not null, add constraint title_unique unique (title);

--- a/examples/alter_column_not_null_lints.md
+++ b/examples/alter_column_not_null_lints.md
@@ -9,7 +9,7 @@ The migration script did not pass all the checks ❌
 ### SQL
 
 ```sql
-alter table books alter column title set not null
+alter table books alter column title set not null, add constraint title_unique unique (title)
 ```
 
 ### Lints
@@ -21,32 +21,6 @@ ID: `E2`
 A column was changed from `NULL` to `NOT NULL`. This blocks all table access until all rows are validated. A safer way is: Add a `CHECK` constraint as `NOT VALID`, validate it later, then make the column `NOT NULL`.
 
 Statement takes `AccessExclusiveLock` on `public.books` by setting `title` to `NOT NULL` blocking reads until all rows are validated
-
-#### Taking dangerous lock without timeout
-
-ID: `E9`
-
-A lock that would block many common operations was taken without a timeout. This can block all other operations on the table indefinitely if any other transaction holds a conflicting lock while `idle in transaction` or `active`. A safer way is: Run `SET LOCAL lock_timeout = '2s';` before the statement and retry the migration if necessary.
-
-Statement takes lock on `public.books`, but does not set a lock timeout
-
-## Statement number 2
-
-### SQL
-
-```sql
-alter table books add constraint title_unique unique (title)
-```
-
-### Lints
-
-#### Running more statements after taking `AccessExclusiveLock`
-
-ID: `E4`
-
-A transaction that holds an `AccessExclusiveLock` started a new statement. This blocks all access to the table for the duration of this statement. A safer way is: Run this statement in a new transaction.
-
-Running more statements after taking `AccessExclusiveLock`
 
 #### Creating a new unique constraint
 

--- a/examples/alter_column_not_null_traced.md
+++ b/examples/alter_column_not_null_traced.md
@@ -16,13 +16,13 @@ There is a summary section for the entire script at the start of the report and 
 
 | Started at | Total duration (ms) | Number of dangerous locks |
 |------------|---------------------|---------------------------|
-| 2021-01-01T01:00:00+01:00 | 20 | 2 ❌ |
+| 2021-01-01T01:00:00+01:00 | 10 | 2 ❌ |
 
 ### All locks found
 
 | Schema | Object | Mode | Relkind | OID | Safe | Duration held (ms) |
 |--------|--------|------|---------|-----|------|--------------------|
-| `public` | `books` | `AccessExclusiveLock` | Table | 1 | ❌ | 20 |
+| `public` | `books` | `AccessExclusiveLock` | Table | 1 | ❌ | 10 |
 | `public` | `books` | `ShareLock` | Table | 1 | ❌ | 10 |
 
 ### Dangerous locks found
@@ -48,7 +48,7 @@ There is a summary section for the entire script at the start of the report and 
 ### SQL
 
 ```sql
-alter table books alter column title set not null
+alter table books alter column title set not null, add constraint title_unique unique (title)
 ```
 
 ### Locks at start
@@ -60,6 +60,7 @@ No locks held at the start of this statement.
 | Schema | Object | Mode | Relkind | OID | Safe |
 |--------|--------|------|---------|-----|------|
 | `public` | `books` | `AccessExclusiveLock` | Table | 1 | ❌ |
+| `public` | `books` | `ShareLock` | Table | 1 | ❌ |
 
 ### Hints
 
@@ -75,44 +76,6 @@ The column `title` in the table `public.books` was changed to `NOT NULL`. If the
 2. Validate the constraint in a later transaction, with `ALTER TABLE public.books VALIDATE CONSTRAINT ...`.
 3. Make the column `NOT NULL`
 
-
-#### Taking dangerous lock without timeout
-
-ID: `E9`
-
-A lock that would block many common operations was taken without a timeout. This can block all other operations on the table indefinitely if any other transaction holds a conflicting lock while `idle in transaction` or `active`. A safer way is: Run `SET LOCAL lock_timeout = '2s';` before the statement and retry the migration if necessary.
-
-The statement took `AccessExclusiveLock` on the Table `public.books` without a timeout. It blocks `SELECT`, `FOR UPDATE`, `FOR NO KEY UPDATE`, `FOR SHARE`, `FOR KEY SHARE`, `UPDATE`, `DELETE`, `INSERT`, `MERGE` while waiting to acquire the lock.
-
-## Statement number 2 for 10 ms
-
-### SQL
-
-```sql
-alter table books add constraint title_unique unique (title)
-```
-
-### Locks at start
-
-| Schema | Object | Mode | Relkind | OID | Safe |
-|--------|--------|------|---------|-----|------|
-| `public` | `books` | `AccessExclusiveLock` | Table | 1 | ❌ |
-
-### New locks taken
-
-| Schema | Object | Mode | Relkind | OID | Safe |
-|--------|--------|------|---------|-----|------|
-| `public` | `books` | `ShareLock` | Table | 1 | ❌ |
-
-### Hints
-
-#### Running more statements after taking `AccessExclusiveLock`
-
-ID: `E4`
-
-A transaction that holds an `AccessExclusiveLock` started a new statement. This blocks all access to the table for the duration of this statement. A safer way is: Run this statement in a new transaction.
-
-The statement is running while holding an `AccessExclusiveLock` on the Table `public.books`, blocking all other transactions from accessing it.
 
 #### Creating a new index on an existing table
 
@@ -136,5 +99,5 @@ ID: `E9`
 
 A lock that would block many common operations was taken without a timeout. This can block all other operations on the table indefinitely if any other transaction holds a conflicting lock while `idle in transaction` or `active`. A safer way is: Run `SET LOCAL lock_timeout = '2s';` before the statement and retry the migration if necessary.
 
-The statement took `ShareLock` on the Table `public.books` without a timeout. It blocks `UPDATE`, `DELETE`, `INSERT`, `MERGE` while waiting to acquire the lock.
+The statement took `AccessExclusiveLock` on the Table `public.books` without a timeout. It blocks `SELECT`, `FOR UPDATE`, `FOR NO KEY UPDATE`, `FOR SHARE`, `FOR KEY SHARE`, `UPDATE`, `DELETE`, `INSERT`, `MERGE` while waiting to acquire the lock.
 

--- a/examples/widen_type_traced.md
+++ b/examples/widen_type_traced.md
@@ -16,7 +16,7 @@ There is a summary section for the entire script at the start of the report and 
 
 | Started at | Total duration (ms) | Number of dangerous locks |
 |------------|---------------------|---------------------------|
-| 2021-01-01T01:00:00+01:00 | 20 | 3 ❌ |
+| 2021-01-01T01:00:00+01:00 | 20 | 4 ❌ |
 
 ### All locks found
 
@@ -24,6 +24,7 @@ There is a summary section for the entire script at the start of the report and 
 |--------|--------|------|---------|-----|------|--------------------|
 | `public` | `books` | `AccessExclusiveLock` | Table | 1 | ❌ | 10 |
 | `public` | `books` | `ShareLock` | Table | 1 | ❌ | 10 |
+| `public` | `books_concurrently_test_idx` | `AccessExclusiveLock` | Index | 1 | ❌ | 10 |
 | `public` | `books_pkey` | `AccessExclusiveLock` | Index | 1 | ❌ | 10 |
 
 ### Dangerous locks found
@@ -39,6 +40,16 @@ There is a summary section for the entire script at the start of the report and 
   + `INSERT`
   + `MERGE`
 - `ShareLock` would block the following operations on `public.books`:
+  + `UPDATE`
+  + `DELETE`
+  + `INSERT`
+  + `MERGE`
+- `AccessExclusiveLock` would block the following operations on `public.books_concurrently_test_idx`:
+  + `SELECT`
+  + `FOR UPDATE`
+  + `FOR NO KEY UPDATE`
+  + `FOR SHARE`
+  + `FOR KEY SHARE`
   + `UPDATE`
   + `DELETE`
   + `INSERT`
@@ -89,6 +100,7 @@ No locks held at the start of this statement.
 |--------|--------|------|---------|-----|------|
 | `public` | `books` | `AccessExclusiveLock` | Table | 1 | ❌ |
 | `public` | `books` | `ShareLock` | Table | 1 | ❌ |
+| `public` | `books_concurrently_test_idx` | `AccessExclusiveLock` | Index | 1 | ❌ |
 | `public` | `books_pkey` | `AccessExclusiveLock` | Index | 1 | ❌ |
 
 ### Hints

--- a/src/hint_data.rs
+++ b/src/hint_data.rs
@@ -96,3 +96,10 @@ pub const ADDED_SERIAL_OR_STORED_GENERATED_COLUMN: StaticHintData = StaticHintDa
     workaround: "Can not be done without a table rewrite",
     effect: "This blocks all table access until the table is rewritten",
 };
+pub const MULTIPLE_ALTER_TABLES_WHERE_ONE_WILL_DO: StaticHintData = StaticHintData {
+    id: "W12",
+    name: "Multiple `ALTER TABLE` statements where one will do",
+    condition: "Multiple `ALTER TABLE` statements targets the same table",
+    workaround: "Combine the statements into one, separating the action with commas",
+    effect: "If the statements require table scans, there will be more scans than necessary",
+};

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -2,6 +2,7 @@ mod snapshot_tests {
     use std::str::FromStr;
 
     use chrono::DateTime;
+    use itertools::Itertools;
 
     use eugene::TraceSettings;
 
@@ -11,6 +12,7 @@ mod snapshot_tests {
             .unwrap()
             .map(|file| file.unwrap())
             .filter(|file| file.path().is_file() && file.path().extension().unwrap() == "sql")
+            .sorted_by_key(|file| file.file_name())
         {
             let file_name = file.file_name().into_string().unwrap();
             let file_title = file_name.trim_end_matches(".sql");


### PR DESCRIPTION
Closes #53 - we recommend doing `alter table` once to each table, possibly with many alter table commands. This enables postgres to execute validations etc in one pass over the table, instead of having to scan it many times, so it might reduce locking issues by reducing lock duration.