### PR TITLE
Make eugene trace and eugene lint support multiple files and folders as input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,7 @@ dependencies = [
  "clap",
  "handlebars",
  "itertools 0.12.1",
+ "nom",
  "once_cell",
  "pg_query",
  "postgres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ itertools = "0.12.1"
 pg_query = "5.1.0"
 handlebars = "5.1.2"
 once_cell = "1.19.0"
+nom = "7.1.3"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/docs/src/shell_output/lint
+++ b/docs/src/shell_output/lint
@@ -40,5 +40,19 @@ Options:
           
           Will still fail for errors in the SQL script.
 
+      --sort-mode <SORT_MODE>
+          Sort mode for script discovery, auto, name or none
+          
+          This is used to order scripts an argument  contains many scripts.
+          
+          `auto` will sort by versions or sequence numbers.
+          
+          `auto` requires all files to have the same naming scheme.
+          
+          `name` will sort lexically by name.
+          
+          [default: auto]
+          [possible values: auto, name, none]
+
   -h, --help
           Print help (see a summary with '-h')

--- a/docs/src/shell_output/lint
+++ b/docs/src/shell_output/lint
@@ -2,11 +2,11 @@ Lint SQL migration script by analyzing syntax tree
 
 `eugene lint` exits with failure if any lint is detected.
 
-Usage: eugene lint [OPTIONS] <PATH>
+Usage: eugene lint [OPTIONS] [paths]...
 
 Arguments:
-  <PATH>
-          Path to SQL migration script, or '-' to read from stdin
+  [paths]...
+          Path to SQL migration scripts, directories, or '-' to read from stdin
 
 Options:
   -v, --var <PLACEHOLDERS>

--- a/docs/src/shell_output/trace
+++ b/docs/src/shell_output/trace
@@ -71,5 +71,19 @@ Options:
           
           Will still fail for invalid SQL or connection problems.
 
+      --sort-mode <SORT_MODE>
+          Sort mode for script discovery, auto, name or none
+          
+          This is used to order scripts an argument  contains many scripts.
+          
+          `auto` will sort by versions or sequence numbers.
+          
+          `auto` requires all files to have the same naming scheme.
+          
+          `name` will sort lexically by name.
+          
+          [default: auto]
+          [possible values: auto, name, none]
+
   -h, --help
           Print help (see a summary with '-h')

--- a/docs/src/shell_output/trace
+++ b/docs/src/shell_output/trace
@@ -4,11 +4,11 @@ Reads $PGPASS for password to postgres, if ~/.pgpass is not found.
 
 `eugene trace` exits with failure if any problems are detected.
 
-Usage: eugene trace [OPTIONS] <PATH>
+Usage: eugene trace [OPTIONS] [paths]...
 
 Arguments:
-  <PATH>
-          Path to SQL migration script, or '-' to read from stdin
+  [paths]...
+          Path to SQL migration script, directories, or '-' to read from stdin
 
 Options:
   -c, --commit

--- a/src/bin/eugene.rs
+++ b/src/bin/eugene.rs
@@ -7,8 +7,11 @@ use eugene::output::output_format::GenericHint;
 use eugene::output::{DetailedLockMode, LockModesWrapper, TerseLockMode};
 use eugene::pg_types::lock_modes;
 use eugene::pgpass::read_pgpass_file;
-use eugene::sqltext::{read_sql_statements, resolve_placeholders};
-use eugene::{output, parse_placeholders, perform_trace, ConnectionSettings, TraceSettings};
+use eugene::script_discovery::script_filters;
+use eugene::sqltext::resolve_placeholders;
+use eugene::{
+    output, parse_placeholders, perform_trace, script_discovery, ConnectionSettings, TraceSettings,
+};
 
 #[derive(Parser)]
 #[command(name = "eugene")]
@@ -35,8 +38,9 @@ enum Commands {
     ///
     /// `eugene lint` exits with failure if any lint is detected.
     Lint {
-        /// Path to SQL migration script, or '-' to read from stdin
-        path: String,
+        /// Path to SQL migration scripts, directories, or '-' to read from stdin
+        #[arg(name = "paths")]
+        paths: Vec<String>,
         /// Provide name=value for replacing ${name} with value in the SQL script
         ///
         /// Can be used multiple times to provide more placeholders.
@@ -72,8 +76,9 @@ enum Commands {
     ///
     /// `eugene trace` exits with failure if any problems are detected.
     Trace {
-        /// Path to SQL migration script, or '-' to read from stdin
-        path: String,
+        /// Path to SQL migration script, directories, or '-' to read from stdin
+        #[arg(name = "paths")]
+        paths: Vec<String>,
         /// Commit at the end of the transaction. Roll back by default.
         #[arg(short = 'c', long = "commit", default_value_t = false)]
         commit: bool,
@@ -195,34 +200,6 @@ struct TraceConfiguration {
     ignored_hints: Vec<String>,
 }
 
-fn trace(
-    provided_connection_settings: ProvidedConnectionSettings,
-    placeholders: Vec<String>,
-    commit: bool,
-    path: String,
-    config: TraceConfiguration,
-) -> Result<(bool, String)> {
-    let connection_settings = provided_connection_settings.try_into()?;
-    let trace_settings = TraceSettings::new(path, commit, &placeholders)?;
-    let ignore_list = config
-        .ignored_hints
-        .iter()
-        .map(|id| id.as_str())
-        .collect_vec();
-    let trace_result = perform_trace(&trace_settings, &connection_settings, &ignore_list)?;
-    let full_trace = output::full_trace_data(
-        &trace_result,
-        output::Settings::new(!config.extra_lock_info, config.skip_summary),
-    );
-
-    let report = match config.trace_format {
-        TraceFormat::Json => full_trace.to_pretty_json(),
-        TraceFormat::Plain => full_trace.to_plain_text(),
-        TraceFormat::Markdown => full_trace.to_markdown(),
-    }?;
-    Ok((trace_result.success(), report))
-}
-
 #[derive(Debug, PartialEq, Eq)]
 enum TraceFormat {
     Json,
@@ -256,28 +233,36 @@ pub fn main() -> Result<()> {
     let args = Eugene::parse();
     match args.command {
         Some(Commands::Lint {
-            path,
+            paths,
             placeholders,
             ignored_hints,
             format,
             accept_failures: exit_success,
         }) => {
-            let format: TraceFormat = format.try_into()?;
-            let sql = read_sql_statements(&path)?;
             let placeholders = parse_placeholders(&placeholders)?;
-            let sql = resolve_placeholders(&sql, &placeholders)?;
-            let report = eugene::lints::lint(
-                if path == "-" { None } else { Some(path) },
-                sql,
-                &ignored_hints.iter().map(|s| s.as_str()).collect_vec(),
-            )?;
-            let failed = report.lints.iter().any(|stmt| !stmt.lints.is_empty());
-            let out = if matches!(format, TraceFormat::Json) {
-                serde_json::to_string_pretty(&report)?
-            } else {
-                output::markdown::lint_report_to_markdown(&report)?
-            };
-            println!("{}", out);
+            let format: TraceFormat = format.try_into()?;
+            let mut failed = false;
+            for target in paths {
+                for read_from in
+                    script_discovery::discover_scripts(&target, script_filters::never, true)?
+                {
+                    let sql = read_from.read()?;
+                    let name = read_from.name();
+                    let sql = resolve_placeholders(&sql, &placeholders)?;
+                    let report = eugene::lints::lint(
+                        Some(name.to_string()),
+                        sql,
+                        &ignored_hints.iter().map(|s| s.as_str()).collect_vec(),
+                    )?;
+                    failed = failed || report.lints.iter().any(|stmt| !stmt.lints.is_empty());
+                    let out = if matches!(format, TraceFormat::Json) {
+                        serde_json::to_string_pretty(&report)?
+                    } else {
+                        output::markdown::lint_report_to_markdown(&report)?
+                    };
+                    println!("{}", out);
+                }
+            }
             if failed && !exit_success {
                 Err(anyhow!("Lint detected"))
             } else {
@@ -291,7 +276,7 @@ pub fn main() -> Result<()> {
             port,
             placeholders,
             commit,
-            path,
+            paths,
             extra,
             skip_summary,
             format,
@@ -304,19 +289,47 @@ pub fn main() -> Result<()> {
                 skip_summary,
                 ignored_hints,
             };
+            let mut connection_settings =
+                ProvidedConnectionSettings::new(user, database, host, port).try_into()?;
+            let mut failed = false;
+            let placeholders = parse_placeholders(&placeholders)?;
+            let ignore_list = config
+                .ignored_hints
+                .iter()
+                .map(|s| s.as_str())
+                .collect_vec();
 
-            let (success, report) = trace(
-                ProvidedConnectionSettings::new(user, database, host, port),
-                placeholders,
-                commit,
-                path,
-                config,
-            )?;
-            println!("{}", report);
-            if success || exit_success {
-                Ok(())
-            } else {
+            for target in paths {
+                let script_source = script_discovery::discover_scripts(
+                    &target,
+                    script_filters::skip_downgrade_and_repeatable,
+                    true,
+                )?;
+                for read_from in script_source {
+                    let sql = read_from.read()?;
+                    let sql = resolve_placeholders(&sql, &placeholders)?;
+                    let name = read_from.name();
+                    let trace_settings = TraceSettings::new(name.to_string(), &sql, commit);
+                    let trace =
+                        perform_trace(&trace_settings, &mut connection_settings, &ignore_list)?;
+                    let full_trace = output::full_trace_data(
+                        &trace,
+                        output::Settings::new(!config.extra_lock_info, config.skip_summary),
+                    );
+                    failed = failed || !trace.success();
+                    let report = match config.trace_format {
+                        TraceFormat::Json => full_trace.to_pretty_json(),
+                        TraceFormat::Plain => full_trace.to_plain_text(),
+                        TraceFormat::Markdown => full_trace.to_markdown(),
+                    }?;
+                    println!("{}", report);
+                }
+            }
+
+            if failed || !exit_success {
                 Err(anyhow!("Trace uncovered problems"))
+            } else {
+                Ok(())
             }
         }
         Some(Commands::Modes { .. }) | None => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ impl ConnectionSettings {
             } else {
                 tx.rollback()?;
             }
+            client.execute("RESET ALL", &[])?;
             Ok(result)
         })
     }

--- a/src/render_doc_snapshots.rs
+++ b/src/render_doc_snapshots.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 
 use crate::lints::lint;
 use crate::output::{full_trace_data, GenericHint, Settings};
-use crate::script_discovery::{discover_scripts, script_filters};
+use crate::script_discovery::{discover_scripts, script_filters, SortMode};
 use crate::{
     generate_new_test_db, hint_data, output, perform_trace, ConnectionSettings, TraceSettings,
 };
@@ -102,7 +102,7 @@ fn snapshot_trace(id: &str, subfolder: &str, output_settings: &Settings) -> Resu
         5432,
         "postgres".to_string(),
     );
-    let sources = discover_scripts(&example_path, script_filters::never, true)?;
+    let sources = discover_scripts(&example_path, script_filters::never, SortMode::Auto)?;
 
     for script in sources {
         let path = script.name().replace('\\', "/");

--- a/src/script_discovery.rs
+++ b/src/script_discovery.rs
@@ -3,13 +3,13 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use anyhow::anyhow;
-use nom::{IResult, Parser};
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::{anychar, char, digit1};
 use nom::combinator::{eof, map, map_res, recognize};
 use nom::multi::{many0, many_till, separated_list1};
 use nom::sequence::terminated;
+use nom::{IResult, Parser};
 
 use crate::script_discovery::script_filters::ScriptFilter;
 
@@ -343,7 +343,11 @@ impl ReadFrom {
 ///
 /// If the path is a file, it is returned as is. If the path is -, stdin is
 /// returned.
-pub fn discover_scripts(path: &str, filter: ScriptFilter, sort: bool) -> anyhow::Result<Vec<ReadFrom>> {
+pub fn discover_scripts(
+    path: &str,
+    filter: ScriptFilter,
+    sort: bool,
+) -> anyhow::Result<Vec<ReadFrom>> {
     let data = std::fs::metadata(path)?;
     if !data.is_file() && path == "-" {
         Ok(vec![ReadFrom::Stdin])
@@ -542,10 +546,12 @@ mod tests {
                     let entry = entry.unwrap();
                     let path = entry.path();
                     if path.is_dir() {
-                        assert!(
-                            sorted_migration_scripts_from_folder(&path, script_filters::never)
-                                .is_ok()
-                        );
+                        assert!(sorted_migration_scripts_from_folder(
+                            &path,
+                            script_filters::never,
+                            true
+                        )
+                        .is_ok());
                     }
                 }
             }

--- a/src/script_discovery.rs
+++ b/src/script_discovery.rs
@@ -1,0 +1,554 @@
+use std::collections::HashSet;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use anyhow::anyhow;
+use nom::{IResult, Parser};
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::character::complete::{anychar, char, digit1};
+use nom::combinator::{eof, map, map_res, recognize};
+use nom::multi::{many0, many_till, separated_list1};
+use nom::sequence::terminated;
+
+use crate::script_discovery::script_filters::ScriptFilter;
+
+/// ScripType is parsed from the first character of the script name,
+/// where U is taken to mean undo, V is taken to mean Versioned, and
+/// R is taken to mean Repeatable. Flyway operates with these
+/// conventions.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum ScriptType {
+    Forward,
+    Back,
+    Repeatable,
+}
+
+/// VersionedName is a script name that normally has a version number
+/// in it, and therefore should be run in a specific order. Some scripts
+/// are [Repeatable](ScriptType::Repeatable) and do not have a version.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct VersionedName<'a> {
+    whole_name: &'a str,
+    version: Vec<u32>,
+    name: &'a str,
+    script_type: ScriptType,
+}
+
+fn parse_sql_file_name_til_eof(name: &str) -> IResult<&str, &str> {
+    let suffix = ".sql";
+    let (rem, name) = recognize(many_till(anychar, terminated(tag(suffix), eof)))(name)?;
+    Ok((rem, &name[..name.len() - suffix.len()]))
+}
+
+fn parse_versioned_name_r(name: &str) -> IResult<&str, VersionedName> {
+    let whole_name = name;
+    let (name, script_type) = map(char('R'), |_| ScriptType::Repeatable)(name)?;
+    let (name, _) = tag("__")(name)?;
+    let (rem, name) = parse_sql_file_name_til_eof(name)?;
+    Ok((
+        rem,
+        VersionedName {
+            whole_name,
+            version: vec![],
+            name,
+            script_type,
+        },
+    ))
+}
+fn parse_versioned_name_uv(name: &str) -> IResult<&str, VersionedName> {
+    let whole_name = name;
+    let (name, script_type) = alt((
+        char('V').map(|_| ScriptType::Forward),
+        char('U').map(|_| ScriptType::Back),
+    ))(name)?;
+    let sep = alt((char('.'), char('_')));
+    let version_part = map_res(digit1, |s: &str| s.parse::<u32>());
+    let (name, version) = separated_list1(sep, version_part)(name)?;
+    let (name, _) = tag("__")(name)?;
+    let (rem, name) = parse_sql_file_name_til_eof(name)?;
+    Ok((
+        rem,
+        VersionedName {
+            whole_name,
+            version,
+            name,
+            script_type,
+        },
+    ))
+}
+
+/// Parses a flyway-style version script name.
+///
+/// There are two variants:
+///   The name should begin with a V or U, followed by a version number, __ and then a name.
+///   The name should begin with R, followed by __ and then a name.
+///
+/// The version number is a list of numbers separated by dots or underscores.
+pub fn parse_versioned_name(name: &str) -> IResult<&str, VersionedName> {
+    alt((parse_versioned_name_r, parse_versioned_name_uv))(name)
+}
+
+/// A script name that starts with a sequence number, which it should be sorted by.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct SequenceNumberName<'a> {
+    whole_name: &'a str,
+    sequence_number: u32,
+    name: &'a str,
+}
+
+fn parse_sequence_number_name(name: &str) -> IResult<&str, SequenceNumberName> {
+    let whole_name = name;
+    let (name, sequence_number) = map_res(digit1, |s: &str| s.parse::<u32>())(name)?;
+    let (name, _) = many0(char('_'))(name)?;
+    let (rem, name) = parse_sql_file_name_til_eof(name)?;
+    Ok((
+        rem,
+        SequenceNumberName {
+            whole_name,
+            sequence_number,
+            name,
+        },
+    ))
+}
+
+/// A script that eugene can not sort by name, because there is no natural ordering in the name.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct SqlName<'a> {
+    whole_name: &'a str,
+    name: &'a str,
+}
+
+fn parse_sql_name(name: &str) -> IResult<&str, SqlName> {
+    let whole_name = name;
+    let (rem, name) = parse_sql_file_name_til_eof(name)?;
+    Ok((rem, SqlName { whole_name, name }))
+}
+
+/// A best effort to parse a script name into something that can be sorted.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum SqlScript<'a> {
+    Versioned(VersionedName<'a>),
+    SequenceNumber(SequenceNumberName<'a>),
+    Sql(SqlName<'a>),
+    Stdin,
+}
+
+impl PartialOrd for SqlScript<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match (self, other) {
+            (SqlScript::Versioned(left), SqlScript::Versioned(right))
+                if !(matches!(left.script_type, ScriptType::Repeatable)
+                    || matches!(right.script_type, ScriptType::Repeatable)) =>
+            {
+                left.version.partial_cmp(&right.version)
+            }
+            (SqlScript::SequenceNumber(left), SqlScript::SequenceNumber(right)) => {
+                left.sequence_number.partial_cmp(&right.sequence_number)
+            }
+            _ => None,
+        }
+    }
+}
+
+/// The type of the script name. Use this to check that you are not trying to sort
+/// incompatible script names, ie. filter out everything that can not be ordered.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum ScriptNameType {
+    Versioned,
+    Sequenced,
+    None,
+}
+
+impl SqlScript<'_> {
+    /// The title of the script name, without sequence number or version
+    pub fn name(&self) -> &str {
+        match self {
+            SqlScript::Versioned(v) => v.name,
+            SqlScript::SequenceNumber(v) => v.name,
+            SqlScript::Sql(v) => v.name,
+            SqlScript::Stdin => "stdin",
+        }
+    }
+    /// The whole script name, including the version or sequence number and suffix
+    pub fn whole_name(&self) -> &str {
+        match self {
+            SqlScript::Versioned(v) => v.whole_name,
+            SqlScript::SequenceNumber(v) => v.whole_name,
+            SqlScript::Sql(v) => v.whole_name,
+            SqlScript::Stdin => "stdin",
+        }
+    }
+    /// What type of name this is, to avoid sorting incompatible names together
+    pub fn script_name_type(&self) -> ScriptNameType {
+        match self {
+            SqlScript::Versioned(_) => ScriptNameType::Versioned,
+            SqlScript::SequenceNumber(_) => ScriptNameType::Sequenced,
+            SqlScript::Sql(_) => ScriptNameType::None,
+            SqlScript::Stdin => ScriptNameType::None,
+        }
+    }
+
+    pub fn read(&self) -> anyhow::Result<String> {
+        match self {
+            SqlScript::Stdin => {
+                let mut buf = String::new();
+                std::io::stdin().read_to_string(&mut buf)?;
+                Ok(buf)
+            }
+            _ => Ok(std::fs::read_to_string(self.whole_name())?),
+        }
+    }
+}
+
+fn parse_sql_script(name: &str) -> IResult<&str, SqlScript> {
+    alt((
+        map(parse_versioned_name, SqlScript::Versioned),
+        map(parse_sequence_number_name, SqlScript::SequenceNumber),
+        map(parse_sql_name, SqlScript::Sql),
+    ))(name)
+}
+
+/// Parse a script name from a file path.
+pub fn parse(path: &Path) -> anyhow::Result<SqlScript> {
+    let name = path
+        .file_name()
+        .ok_or_else(|| anyhow!("No file name found"))?
+        .to_str()
+        .ok_or_else(|| anyhow!("File name is not valid UTF-8"))?;
+    parse_sql_script(name)
+        .map(|(_, script)| script)
+        .map_err(|e| anyhow!("Failed to parse script name: {:?}", e))
+}
+
+fn all_files_with_sql_suffix(dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    let mut entries = vec![];
+    for entry in dir.read_dir()? {
+        let entry = entry?;
+        let metadata = entry.metadata()?;
+        if metadata.is_file() {
+            let path = entry.path();
+            if let Some(ext) = path.extension() {
+                if ext == "sql" {
+                    entries.push(entry.path());
+                }
+            }
+        }
+    }
+    Ok(entries)
+}
+
+pub mod script_filters {
+    use super::*;
+
+    pub type ScriptFilter = fn(&SqlScript) -> bool;
+    pub fn never(_: &SqlScript) -> bool {
+        true
+    }
+    pub fn repatable_versioned(s: &SqlScript) -> bool {
+        !matches!(s, SqlScript::Versioned(v) if v.script_type == ScriptType::Repeatable)
+    }
+    pub fn back(s: &SqlScript) -> bool {
+        !matches!(s, SqlScript::Versioned(v) if v.script_type == ScriptType::Back)
+    }
+    pub fn skip_downgrade_and_repeatable(s: &SqlScript) -> bool {
+        back(s) || repatable_versioned(s)
+    }
+}
+
+fn sort_paths_by_script_type(
+    paths: &[PathBuf],
+    filter: ScriptFilter,
+) -> anyhow::Result<Vec<PathBuf>> {
+    let scripts: anyhow::Result<Vec<_>> =
+        paths.iter().map(|p| Ok((p.clone(), parse(p)?))).collect();
+    let mut scripts = scripts?;
+    // Make some checks first, ensure that we can sort the paths,
+    // they must all parse to something sortable of the same kind
+
+    let script_types = scripts
+        .iter()
+        .map(|(_, s)| s.script_name_type())
+        .collect::<HashSet<_>>();
+    if script_types.len() > 1 {
+        return Err(anyhow!(
+            "Can not sort scripts of different types: {:?}",
+            script_types
+        ));
+    }
+    if script_types.contains(&ScriptNameType::None) {
+        return Err(anyhow!(
+            "Can not sort scripts without a sequence number or version"
+        ));
+    }
+    scripts.retain(|(_, s)| filter(s));
+    scripts.sort_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    Ok(scripts.into_iter().map(|(p, _)| p).collect())
+}
+
+/// Retrieves all SQL scripts from a folder and sorts them by their name
+///
+/// Errors if the folder does not exist, or if the scripts are of different types.
+///
+/// Sorting rules and discovered naming standards are:
+///
+/// - Versioned scripts are sorted by their version number according to flyway-like rules
+/// - Scripts that start with a sequence number are sorted by that number (as an integer)
+/// - Scripts that do not match any of the above are not sorted and an error is returned
+pub fn sorted_migration_scripts_from_folder(
+    dir: &Path,
+    filter: ScriptFilter,
+    sort: bool,
+) -> anyhow::Result<Vec<PathBuf>> {
+    let paths = all_files_with_sql_suffix(dir)?;
+    if sort {
+        sort_paths_by_script_type(&paths, filter)
+    } else {
+        Ok(paths)
+    }
+}
+
+/// A source for reading a SQL script from.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ReadFrom {
+    Stdin,
+    File(String),
+}
+
+impl ReadFrom {
+    pub fn read(&self) -> anyhow::Result<String> {
+        match self {
+            ReadFrom::Stdin => {
+                let mut buf = String::new();
+                std::io::stdin().read_to_string(&mut buf)?;
+                Ok(buf)
+            }
+            ReadFrom::File(path) => Ok(std::fs::read_to_string(path)?),
+        }
+    }
+    pub fn name(&self) -> &str {
+        match self {
+            ReadFrom::Stdin => "stdin",
+            ReadFrom::File(path) => path,
+        }
+    }
+}
+
+/// Discover scripts from a path, which can be a file or a directory, or -.
+///
+/// If the path is a directory, all files with the .sql suffix are discovered.
+/// When `sort` is true, the scripts are sorted by the version names if they
+/// are versioned, or by the sequence number if they are sequenced. If the
+/// sorting is ambiguous, an error is returned.
+///
+/// If the path is a file, it is returned as is. If the path is -, stdin is
+/// returned.
+pub fn discover_scripts(path: &str, filter: ScriptFilter, sort: bool) -> anyhow::Result<Vec<ReadFrom>> {
+    let data = std::fs::metadata(path)?;
+    if !data.is_file() && path == "-" {
+        Ok(vec![ReadFrom::Stdin])
+    } else if data.is_file() {
+        Ok(vec![ReadFrom::File(path.to_string())])
+    } else if data.is_dir() {
+        let paths = sorted_migration_scripts_from_folder(&PathBuf::from(path), filter, sort)?;
+        Ok(paths
+            .into_iter()
+            .map(|p| ReadFrom::File(p.to_string_lossy().to_string()))
+            .collect())
+    } else {
+        Err(anyhow!("Path is not a file or directory"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nom::error::ErrorKind::Eof;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn parses_versioned_names() {
+        let expect = VersionedName {
+            whole_name: "V1_2__create_table.sql",
+            version: vec![1, 2],
+            name: "create_table",
+            script_type: ScriptType::Forward,
+        };
+        assert_eq!(parse_versioned_name(expect.whole_name).unwrap().1, expect);
+        let expect = VersionedName {
+            whole_name: "U1_2__drop_table.sql",
+            version: vec![1, 2],
+            name: "drop_table",
+            script_type: ScriptType::Back,
+        };
+        assert_eq!(parse_versioned_name(expect.whole_name).unwrap().1, expect);
+        let expect = VersionedName {
+            whole_name: "R__create_table.sql",
+            version: vec![],
+            name: "create_table",
+            script_type: ScriptType::Repeatable,
+        };
+        let whole_name = "R_1_2_3__create_table.sql"; // not valid
+        assert_eq!(parse_versioned_name(expect.whole_name).unwrap().1, expect);
+        let expect = Err(nom::Err::Error(nom::error::Error {
+            input: whole_name,
+            code: nom::error::ErrorKind::Char,
+        }));
+        assert_eq!(parse_versioned_name(whole_name), expect);
+        let expect = Err(nom::Err::Error(nom::error::Error {
+            input: "T1__create_table.old.sql",
+            code: nom::error::ErrorKind::Char,
+        }));
+        assert_eq!(parse_versioned_name("T1__create_table.old.sql"), expect);
+    }
+
+    #[test]
+    fn parses_sequence_number_name() {
+        let expect = SequenceNumberName {
+            whole_name: "1__create_table.sql",
+            sequence_number: 1,
+            name: "create_table",
+        };
+        assert_eq!(
+            parse_sequence_number_name(expect.whole_name).unwrap().1,
+            expect
+        );
+        let expect = SequenceNumberName {
+            whole_name: "2__drop_table.sql",
+            sequence_number: 2,
+            name: "drop_table",
+        };
+        assert_eq!(
+            parse_sequence_number_name(expect.whole_name).unwrap().1,
+            expect
+        );
+        let expect = Err(nom::Err::Error(nom::error::Error {
+            input: "T1__create_table.old.sql",
+            code: nom::error::ErrorKind::Digit,
+        }));
+        assert_eq!(
+            parse_sequence_number_name("T1__create_table.old.sql"),
+            expect
+        );
+        let name = "1.sql";
+        let expect = SequenceNumberName {
+            whole_name: name,
+            sequence_number: 1,
+            name: "",
+        };
+        assert_eq!(parse_sequence_number_name(name).unwrap().1, expect);
+    }
+
+    #[test]
+    fn parses_sql_name() {
+        let expect = SqlName {
+            whole_name: "create_table.sql",
+            name: "create_table",
+        };
+        assert_eq!(parse_sql_name(expect.whole_name).unwrap().1, expect,);
+        let expect = SqlName {
+            whole_name: "drop_table.sql",
+            name: "drop_table",
+        };
+        assert_eq!(parse_sql_name(expect.whole_name).unwrap().1, expect,);
+        let expect = Err(nom::Err::Error(nom::error::Error {
+            input: "",
+            code: Eof,
+        }));
+        assert_eq!(parse_sql_name("create_table.old.xlsx"), expect,);
+    }
+
+    #[test]
+    fn parses_sql_script() {
+        let versioned = SqlScript::Versioned(VersionedName {
+            whole_name: "V1_2__create_table.sql",
+            version: vec![1, 2],
+            name: "create_table",
+            script_type: ScriptType::Forward,
+        });
+        let numbered = SqlScript::SequenceNumber(SequenceNumberName {
+            whole_name: "1__create_table.sql",
+            sequence_number: 1,
+            name: "create_table",
+        });
+        let sql = SqlScript::Sql(SqlName {
+            whole_name: "create_table.sql",
+            name: "create_table",
+        });
+        assert_eq!(
+            Ok(("", versioned.clone())),
+            parse_sql_script(versioned.whole_name())
+        );
+        assert_eq!(
+            Ok(("", numbered.clone())),
+            parse_sql_script(numbered.whole_name())
+        );
+        assert_eq!(Ok(("", sql.clone())), parse_sql_script(sql.whole_name()));
+    }
+
+    #[test]
+    fn test_sorted_mixed_types_errors() {
+        let paths = vec![
+            PathBuf::from("1__create_table.sql"),
+            PathBuf::from("V1_2__create_table.sql"),
+        ];
+        let res = sort_paths_by_script_type(&paths, script_filters::never);
+        assert!(res.is_err());
+        let paths = vec![
+            PathBuf::from("1_create_table.sql"),
+            PathBuf::from("create_table.sql"),
+        ];
+        let res = sort_paths_by_script_type(&paths, script_filters::never);
+        assert!(res.is_err());
+        let paths = vec![
+            PathBuf::from("1__create_table.sql"),
+            PathBuf::from("R__create_table.sql"),
+        ];
+        let res = sort_paths_by_script_type(&paths, script_filters::never);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn can_remove_repeatable_scripts() {
+        let paths = vec![
+            PathBuf::from("V1__create_table.sql"),
+            PathBuf::from("R__create_table.sql"),
+        ];
+        let res = sort_paths_by_script_type(&paths, script_filters::repatable_versioned);
+        assert_eq!(res.unwrap(), vec![PathBuf::from("V1__create_table.sql")]);
+    }
+
+    #[test]
+    fn can_remove_downgrades() {
+        let paths = vec![
+            PathBuf::from("V1__create_table.sql"),
+            PathBuf::from("U1__create_table.sql"),
+        ];
+        let res = sort_paths_by_script_type(&paths, script_filters::back);
+        assert_eq!(res.unwrap(), vec![PathBuf::from("V1__create_table.sql")]);
+    }
+
+    #[test]
+    fn check_all_examples_sort() {
+        let examples_dir = "examples";
+        // Iterate over every subdirectory in the examples directory
+        for entry in std::fs::read_dir(examples_dir).unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            if path.is_dir() {
+                // Iterate over every subdirectory in path
+                for entry in std::fs::read_dir(&path).unwrap() {
+                    let entry = entry.unwrap();
+                    let path = entry.path();
+                    if path.is_dir() {
+                        assert!(
+                            sorted_migration_scripts_from_folder(&path, script_filters::never)
+                                .is_ok()
+                        );
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Take a stab at https://github.com/kaaveland/eugene/issues/65 by hooking up eugene trace and eugene lint with script
discovery. It recognizes flyway style folders of versioned migrations and
sequence numbered scripts automatically. This is an early version still,
and there's lots of behavioural changes to look at (eg. should we
automatically set --commit, or refuse to trace many scripts when
it isn't set?)

The most important parameters of the current behaviour are:

- We never sort parameters provided on the command line. This means that we run
  scripts in the order they are provided.
- When provided a folder, we list all files ending in .sql and if they all have
  the same naming standard (eg. V1.*__name.sql or 13_.*.sql), we sort them in
  the correct order and run on them.
- We currently reuse the connection for eugene trace, but I think we may need
  to clean up session state to keep doing this.
- We run 1 script at the time, print the report and keep going.
- Unless there's an error, we run on all scripts before we set the exit code.