### PR TITLE
Generate shell completions for bash, zsh, fish, pwsh, elvis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +401,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "clap_complete",
  "handlebars",
  "itertools 0.12.1",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ pg_query = "5.1.0"
 handlebars = "5.1.2"
 once_cell = "1.19.0"
 nom = "7.1.3"
+clap_complete = "4.5.2"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ available over at the [user documentation site](https://kaveland.no/eugene). Thi
 is primarily for development work on `eugene`, with only small convenience sections
 for users.
 
+Links:
+
+- [User Documentation](https://kaveland.no/eugene)
+- [crates.io/crates/eugene](https://crates.io/crates/eugene)
+- [docs.rs/eugene](https://docs.rs/eugene)
+- [Repository](https://github.com/kaaveland/eugene)
+
 ## Installation
 
 The tool documentation at [kaveland.no/eugene](https://kaveland.no/eugene) is the 

--- a/docs/src/shell_output/help
+++ b/docs/src/shell_output/help
@@ -9,12 +9,13 @@ concurrent transactions that would be blocked.
 Usage: eugene [COMMAND]
 
 Commands:
-  lint     Lint SQL migration script by analyzing syntax tree
-  trace    Trace effects by running statements from SQL migration script
-  modes    List postgres lock modes
-  explain  Explain what operations a lock mode allows and conflicts with
-  hints    Show migration hints that eugene can detect in traces
-  help     Print this message or the help of the given subcommand(s)
+  lint         Lint SQL migration script by analyzing syntax tree
+  trace        Trace effects by running statements from SQL migration script
+  modes        List postgres lock modes
+  explain      Explain what operations a lock mode allows and conflicts with
+  hints        Show migration hints that eugene can detect in traces
+  completions  Generate shell completions for eugene
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help


### PR DESCRIPTION
Closes #73 

Put `eval "$(eugene completions)"` in `~/.bashrc` or in the right `completion.d` folder.