### PR TITLE
Make eugene create a temporary postgres instance

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Run tests
         env:
           TZ: UTC
+          RUST_LOG: eugene=trace
         run: cargo test --all-targets --all-features
 
   run_tests_macos:
@@ -75,6 +76,7 @@ jobs:
       - name: Run tests
         env:
           TZ: UTC
+          RUST_LOG: eugene=trace
         run: cargo test --all-targets --all-features
       - name: Stop postgres
         run: pg_ctl -D $HOME/pgdata stop
@@ -110,4 +112,5 @@ jobs:
       - name: Run tests
         env:
           TZ: UTC
+          RUST_LOG: eugene=trace
         run: cargo test --all-targets --all-features

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -39,11 +39,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up psql
-        run: sudo apt-get install -y postgresql-client
+        run: sudo apt-get install -y postgresql-client postgresql
       - name: Make ~/.pgpass
         run: echo "localhost:5432:*:postgres:$PGPASS" > ~/.pgpass && chmod 600 ~/.pgpass
       - name: Init testdb
         run: psql --host localhost --port 5432 -U postgres < db-initscripts/init-testdb.sql
+      - name: Put postgres binaries on PATH for tests
+        run: echo "/usr/lib/postgresql/14/bin" >> $GITHUB_PATH
       - name: Run tests
         env:
           TZ: UTC

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,10 +434,12 @@ dependencies = [
  "pg_query",
  "postgres",
  "pretty_assertions",
+ "rand",
  "rayon",
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ nom = "7.1.3"
 clap_complete = "4.5.2"
 log = { version = "0.4.21", features = ["kv"] }
 env_logger = "0.11.3"
+tempfile = "3.10.1"
+rand = "0.8.5"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM postgres:alpine
 
+
 ARG TARGETARCH
 COPY ./eugene-${TARGETARCH} /usr/local/bin/eugene
 RUN chmod +x /usr/local/bin/eugene
+
+RUN adduser -D eugene
+USER eugene
 
 ENTRYPOINT ["/usr/local/bin/eugene"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM postgres:alpine
 
 ARG TARGETARCH
 COPY ./eugene-${TARGETARCH} /usr/local/bin/eugene

--- a/docs/src/shell_output/trace
+++ b/docs/src/shell_output/trace
@@ -85,5 +85,14 @@ Options:
           [default: auto]
           [possible values: auto, name, none]
 
+      --disable-temporary
+          Disable creation of temporary postgres server for tracing
+          
+          By default, trace will create a postgres server in a temporary directory
+          
+          This relies on having `initdb` and `pg_ctl` in PATH, which eugene images have.
+          
+          Eugene deletes the temporary database cluster when done tracing.
+
   -h, --help
           Print help (see a summary with '-h')

--- a/src/bin/eugene.rs
+++ b/src/bin/eugene.rs
@@ -3,6 +3,7 @@ use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::generate;
 use clap_complete::Shell::{Bash, Elvish, Fish, PowerShell, Zsh};
 use itertools::Itertools;
+use postgres::Client;
 use serde::Serialize;
 
 use eugene::output::output_format::GenericHint;
@@ -11,8 +12,10 @@ use eugene::pg_types::lock_modes;
 use eugene::pgpass::read_pgpass_file;
 use eugene::script_discovery::script_filters;
 use eugene::sqltext::resolve_placeholders;
+use eugene::tempserver::TempServer;
 use eugene::{
     output, parse_placeholders, perform_trace, script_discovery, ConnectionSettings, TraceSettings,
+    WithClient,
 };
 
 #[derive(Parser)]
@@ -156,6 +159,16 @@ enum Commands {
         /// `name` will sort lexically by name.
         #[arg(long = "sort-mode", default_value = "auto", value_parser=clap::builder::PossibleValuesParser::new(["auto", "name", "none"]))]
         sort_mode: String,
+
+        /// Disable creation of temporary postgres server for tracing
+        ///
+        /// By default, trace will create a postgres server in a temporary directory
+        ///
+        /// This relies on having `initdb` and `pg_ctl` in PATH, which eugene images have.
+        ///
+        /// Eugene deletes the temporary database cluster when done tracing.
+        #[arg(long = "disable-temporary", default_value_t = true)]
+        temporary_postgres: bool,
     },
     /// List postgres lock modes
     Modes {
@@ -265,6 +278,20 @@ impl TryFrom<String> for TraceFormat {
     }
 }
 
+enum ClientSource {
+    TempDb(TempServer),
+    Connect(ConnectionSettings),
+}
+
+impl WithClient for ClientSource {
+    fn with_client<T>(&mut self, f: impl FnOnce(&mut Client) -> Result<T>) -> Result<T> {
+        match self {
+            ClientSource::TempDb(temp) => temp.with_client(f),
+            ClientSource::Connect(settings) => settings.with_client(f),
+        }
+    }
+}
+
 pub fn main() -> Result<()> {
     env_logger::init();
     let args = Eugene::parse();
@@ -328,6 +355,7 @@ pub fn main() -> Result<()> {
             ignored_hints,
             accept_failures: exit_success,
             sort_mode,
+            temporary_postgres,
         }) => {
             let config = TraceConfiguration {
                 trace_format: format.try_into()?,
@@ -335,8 +363,13 @@ pub fn main() -> Result<()> {
                 skip_summary,
                 ignored_hints,
             };
-            let mut connection_settings =
-                ProvidedConnectionSettings::new(user, database, host, port).try_into()?;
+            let provided = ProvidedConnectionSettings::new(user, database, host, port);
+            let mut client_source = if temporary_postgres {
+                ClientSource::TempDb(TempServer::new()?)
+            } else {
+                ClientSource::Connect(provided.try_into()?)
+            };
+
             let mut failed = false;
             let placeholders = parse_placeholders(&placeholders)?;
             let ignore_list = config
@@ -361,7 +394,7 @@ pub fn main() -> Result<()> {
                 let sql = resolve_placeholders(&sql, &placeholders)?;
                 let name = read_from.name();
                 let trace_settings = TraceSettings::new(name.to_string(), &sql, commit);
-                let trace = perform_trace(&trace_settings, &mut connection_settings, &ignore_list)
+                let trace = perform_trace(&trace_settings, &mut client_source, &ignore_list)
                     .map_err(|e| anyhow!("Error tracing {name}: {e}"))?;
                 let full_trace = output::full_trace_data(
                     &trace,

--- a/src/bin/eugene.rs
+++ b/src/bin/eugene.rs
@@ -357,6 +357,7 @@ pub fn main() -> Result<()> {
             sort_mode,
             temporary_postgres,
         }) => {
+            let commit = commit || temporary_postgres;
             let config = TraceConfiguration {
                 trace_format: format.try_into()?,
                 extra_lock_info: extra,

--- a/src/tempserver.rs
+++ b/src/tempserver.rs
@@ -1,0 +1,201 @@
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, Command};
+use std::sync::mpsc::channel;
+use std::thread::{spawn, JoinHandle};
+
+use crate::{ConnectionSettings, WithClient};
+use anyhow::{anyhow, Context, Result};
+use log::{debug, error, info, warn};
+use postgres::Client;
+use tempfile::TempDir;
+
+pub struct TempServer {
+    dbpath: Option<TempDir>,
+    child: Child,
+    reader: Option<JoinHandle<()>>,
+    logger: Option<JoinHandle<()>>,
+    connection_settings: ConnectionSettings,
+}
+
+impl TempServer {
+    pub fn new() -> Result<Self> {
+        let port = find_free_port_on_localhost()?;
+        check_required_postgres_commands()?;
+        let dbpath = TempDir::new()?;
+        let mut superuser_password = String::new();
+        while superuser_password.len() < 20 {
+            let rand_byte: u8 = rand::random();
+            if rand_byte.is_ascii_alphanumeric() {
+                superuser_password.push(rand_byte as char);
+            }
+        }
+        let mut pwfile = tempfile::NamedTempFile::new()?;
+        pwfile.write_all(superuser_password.as_bytes())?;
+
+        assert!(dbpath.path().exists());
+        let initdb = Command::new("initdb")
+            .arg("-D")
+            .arg(dbpath.path())
+            .arg("--pwfile")
+            .arg(pwfile.path())
+            .arg("--username")
+            .arg("postgres")
+            .output()?;
+
+        if !initdb.status.success() {
+            return Err(anyhow!("initdb failed: {initdb:?}",));
+        }
+
+        let mut pg = Command::new("pg_ctl");
+        pg.arg("start")
+            .arg("-D")
+            .arg(dbpath.path())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .arg("-o")
+            .arg(format!("-p {port}"))
+            .arg("-o")
+            .arg(format!(
+                "-c unix_socket_directories={}",
+                dbpath.path().to_string_lossy()
+            ));
+
+        let mut child = pg.spawn()?;
+        let (sender, receiver) = channel();
+        let stdout = child.stdout.take().context("Unable to take stdout")?;
+
+        let reader = spawn(move || {
+            let r = BufReader::new(stdout);
+            for line in r.lines().map_while(Result::ok) {
+                if let Err(e) = sender.send(line) {
+                    error!("Unable to send log: {e:?}");
+                    break;
+                }
+            }
+        });
+
+        loop {
+            let log = receiver.recv()?;
+            info!("postgres log: {log}");
+            if log.contains("ready to accept") {
+                break;
+            }
+        }
+
+        let logger = spawn(move || loop {
+            let log = receiver.recv();
+            match log {
+                Ok(l) => {
+                    debug!("postgres log: {}", l);
+                }
+                Err(e) => {
+                    warn!("Unable to receive log from postgres: {e:}");
+                    break;
+                }
+            }
+        });
+
+        Ok(TempServer {
+            dbpath: Some(dbpath),
+            child,
+            reader: Some(reader),
+            logger: Some(logger),
+            connection_settings: ConnectionSettings::new(
+                "postgres".to_string(),
+                "postgres".to_string(),
+                "localhost".to_string(),
+                port,
+                superuser_password.clone(),
+            ),
+        })
+    }
+}
+
+fn check_required_postgres_commands() -> Result<()> {
+    let required = ["initdb", "postgres"];
+    for command in required.iter() {
+        Command::new(command)
+            .arg("--help")
+            .output()
+            .map_err(|err| {
+                anyhow!(
+                    "This functionality requires {command}, but it isn't available on PATH: {err}"
+                )
+            })?;
+    }
+    Ok(())
+}
+
+fn find_free_port_on_localhost() -> Result<u16> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    Ok(port)
+}
+
+impl WithClient for TempServer {
+    fn with_client<T>(&mut self, f: impl FnOnce(&mut Client) -> Result<T>) -> Result<T> {
+        self.connection_settings.with_client(f)
+    }
+}
+
+impl Drop for TempServer {
+    fn drop(&mut self) {
+        debug!("Dropping TempServer at {:?}", &self.dbpath);
+        let path_name = self.dbpath.as_ref().map(|d| d.path());
+
+        // This matches unless drop has already run
+        if let Some(path_name) = path_name {
+            let r = Command::new("pg_ctl")
+                .arg("stop")
+                .arg("-D")
+                .arg(path_name)
+                .arg("-m")
+                .arg("immediate")
+                .output();
+
+            if let Err(problem) = r {
+                warn!("Trouble stopping postgres: {problem:?}");
+            }
+        }
+
+        let child = self.child.kill();
+        match child {
+            Err(e) => info!("Failed to stop postgres: {:?}", e),
+            Ok(()) => {
+                debug!("Stopped postgres, deleting {:?}", self.dbpath);
+                if let Some(dbpath) = self.dbpath.take() {
+                    if let Err(e) = dbpath.close() {
+                        warn!("Failed to delete tempdir: {:?}", e);
+                    }
+                }
+            }
+        }
+
+        // These both match since this is the only place where we .take()
+        // and drop can't run twice
+        if let Some(reader) = self.reader.take() {
+            if let Err(e) = reader.join() {
+                warn!("Unable to join reader thread: {e:?}");
+            }
+        }
+        if let Some(logger) = self.logger.take() {
+            if let Err(e) = logger.join() {
+                warn!("Unable to join logger thread: {e:?}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_make_temporary_dbserver() {
+        let mut s = TempServer::new().unwrap();
+        let rows: Vec<_> = s
+            .with_client(|client| Ok(client.query("SELECT 1 + 1", &[]).unwrap()))
+            .unwrap();
+        assert!(!rows.is_empty());
+    }
+}

--- a/src/tempserver.rs
+++ b/src/tempserver.rs
@@ -192,6 +192,7 @@ mod tests {
 
     #[test]
     fn can_make_temporary_dbserver() {
+        env_logger::init();
         let mut s = TempServer::new().unwrap();
         let rows: Vec<_> = s
             .with_client(|client| Ok(client.query("SELECT 1 + 1", &[]).unwrap()))


### PR DESCRIPTION
The instance is created using `initdb` and `pg_initctl` from the postgres package on the user system, if they exist. Eugene manages the lifecycle of the temporary server and destroys it, and its files etc when done with it.

Going to have to iterate on this a bit to figure out how it should look. This is a nice capability, but there are lots of questions when going this route:

- It should probably be on by default, but that interacts weirdly with --commit which is off by default
- We have to decide if we should expose the ability to pass options to `initdb` and `postgres`. This complicates the UI a fair bit.