### PR TITLE
Refactor cli parsing in eugene.rs

### DIFF
--- a/eugene/docs/src/shell_output/lint
+++ b/eugene/docs/src/shell_output/lint
@@ -17,9 +17,7 @@ Options:
   -i, --ignore <IGNORED_HINTS>
           Ignore the hints with these IDs, use `eugene hints` to see available hints
           
-          Can be used multiple times.
-          
-          Example: `eugene lint -i E3 -i E4`
+          Can be used multiple times: `-i E3 -i E4`
           
           Or comment your SQL statement like this:
           

--- a/eugene/docs/src/shell_output/lint
+++ b/eugene/docs/src/shell_output/lint
@@ -36,7 +36,7 @@ Options:
   -a, --accept-failures
           Exit successfully even if problems are detected.
           
-          Will still fail for errors in the SQL script.
+          Will still fail for syntax errors in the SQL script.
 
       --sort-mode <SORT_MODE>
           Sort mode for script discovery, auto, name or none

--- a/eugene/docs/src/shell_output/lint
+++ b/eugene/docs/src/shell_output/lint
@@ -41,11 +41,11 @@ Options:
       --sort-mode <SORT_MODE>
           Sort mode for script discovery, auto, name or none
           
-          This is used to order scripts when an argument contains many scripts.
+          This is used to order scripts when a path is a directory, or many paths are provided.
           
           `auto` will sort by versions or sequence numbers.
           
-          `auto` requires all files to have the same naming scheme.
+          `auto` requires all files to have the same naming scheme, either flyway-style or leading sequence numbers.
           
           `name` will sort lexically by name.
           

--- a/eugene/docs/src/shell_output/trace
+++ b/eugene/docs/src/shell_output/trace
@@ -8,42 +8,26 @@ Usage: eugene trace [OPTIONS] [paths]...
 
 Arguments:
   [paths]...
-          Path to SQL migration script, directories, or '-' to read from stdin
+          Path to SQL migration scripts, directories, or '-' to read from stdin
 
 Options:
-  -c, --commit
-          Commit at the end of the transaction. Roll back by default
-
   -v, --var <PLACEHOLDERS>
           Provide name=value for replacing ${name} with value in the SQL script
           
           Can be used multiple times to provide more placeholders.
 
-  -U, --user <USER>
-          Username to use for connecting to postgres
+  -i, --ignore <IGNORED_HINTS>
+          Ignore the hints with these IDs, use `eugene hints` to see available hints
           
-          [default: postgres]
-
-  -d, --database <DATABASE>
-          Database to connect to
+          Can be used multiple times: `-i E3 -i E4`
           
-          [default: postgres]
-
-  -H, --host <HOST>
-          Host to connect to
+          Or comment your SQL statement like this:
           
-          [default: localhost]
-
-  -p, --port <PORT>
-          Port to connect to
+          `-- eugene-ignore: E3, E4`
           
-          [default: 5432]
-
-  -e, --extra
-          Show locks that are normally not in conflict with application code
-
-  -s, --skip-summary
-          Skip the summary section for markdown output
+          alter table foo add column bar json;
+          
+          This will ignore hints E3 and E4 for this statement only.
 
   -f, --format <FORMAT>
           Output format, plain, json or markdown
@@ -51,25 +35,10 @@ Options:
           [default: plain]
           [possible values: json, markdown, md, plain]
 
-  -i, --ignore <IGNORED_HINTS>
-          Ignore the hints with these IDs, use `eugene hints` to see available hints
-          
-          Can be used multiple times.
-          
-          Example: `eugene trace -i E3 -i E4`
-          
-          Or comment your SQL statement like this to ignore for a single statement:
-          
-          -- eugene: ignore E4
-          
-          alter table foo add column bar json;
-          
-          Use `-- eugene: ignore` to ignore all hints for a statement.
-
   -a, --accept-failures
-          Exit successfully even if problems are detected
+          Exit successfully even if problems are detected.
           
-          Will still fail for invalid SQL or connection problems.
+          Will still fail for errors in the SQL script.
 
       --sort-mode <SORT_MODE>
           Sort mode for script discovery, auto, name or none
@@ -84,6 +53,9 @@ Options:
           
           [default: auto]
           [possible values: auto, name, none]
+
+  -s, --skip-summary
+          Skip the summary section for markdown output
 
       --disable-temporary
           Disable creation of temporary postgres server for tracing
@@ -107,6 +79,32 @@ Options:
           Example: `eugene trace --initdb "--encoding=UTF8"`
           
           Supply it more than once to add multiple options.
+
+  -U, --user <USER>
+          Username to use for connecting to postgres
+          
+          [default: postgres]
+
+  -d, --database <DATABASE>
+          Database to connect to
+          
+          [default: postgres]
+
+  -H, --host <HOST>
+          Host to connect to
+          
+          [default: localhost]
+
+  -p, --port <PORT>
+          Port to connect to
+          
+          [default: 5432]
+
+  -c, --commit
+          Commit at the end of the transaction. Roll back by default
+
+  -e, --extra
+          Show locks that are normally not in conflict with application code
 
   -h, --help
           Print help (see a summary with '-h')

--- a/eugene/docs/src/shell_output/trace
+++ b/eugene/docs/src/shell_output/trace
@@ -38,7 +38,7 @@ Options:
   -a, --accept-failures
           Exit successfully even if problems are detected.
           
-          Will still fail for errors in the SQL script.
+          Will still fail for syntax errors in the SQL script.
 
       --sort-mode <SORT_MODE>
           Sort mode for script discovery, auto, name or none

--- a/eugene/docs/src/shell_output/trace
+++ b/eugene/docs/src/shell_output/trace
@@ -1,5 +1,7 @@
 Trace effects by running statements from SQL migration script
 
+`eugene trace` will set up a temporary postgres server to run against, unless disabled.
+
 Reads $PGPASS for password to postgres, if ~/.pgpass is not found.
 
 `eugene trace` exits with failure if any problems are detected.
@@ -43,11 +45,11 @@ Options:
       --sort-mode <SORT_MODE>
           Sort mode for script discovery, auto, name or none
           
-          This is used to order scripts when an argument contains many scripts.
+          This is used to order scripts when a path is a directory, or many paths are provided.
           
           `auto` will sort by versions or sequence numbers.
           
-          `auto` requires all files to have the same naming scheme.
+          `auto` requires all files to have the same naming scheme, either flyway-style or leading sequence numbers.
           
           `name` will sort lexically by name.
           
@@ -101,7 +103,9 @@ Options:
           [default: 5432]
 
   -c, --commit
-          Commit at the end of the transaction. Roll back by default
+          Commit at the end of the transaction.
+          
+          Commit is always enabled for the temporary server, otherwise rollback is default.
 
   -e, --extra
           Show locks that are normally not in conflict with application code

--- a/eugene/src/lib.rs
+++ b/eugene/src/lib.rs
@@ -52,7 +52,7 @@ mod render_doc_snapshots;
 pub mod tempserver;
 
 /// Connection settings for connecting to a PostgreSQL database.
-pub struct ConnectionSettings {
+pub struct ClientSource {
     user: String,
     database: String,
     host: String,
@@ -61,7 +61,7 @@ pub struct ConnectionSettings {
     client: Option<Client>,
 }
 
-impl ConnectionSettings {
+impl ClientSource {
     pub fn connection_string(&self) -> String {
         let out = format!(
             "host={} user={} dbname={} port={} password={}",
@@ -70,7 +70,7 @@ impl ConnectionSettings {
         out
     }
     pub fn new(user: String, database: String, host: String, port: u16, password: String) -> Self {
-        ConnectionSettings {
+        ClientSource {
             user,
             database,
             host,
@@ -106,7 +106,7 @@ pub trait WithClient {
     }
 }
 
-impl WithClient for ConnectionSettings {
+impl WithClient for ClientSource {
     fn with_client<T>(
         &mut self,
         f: impl FnOnce(&mut Client) -> anyhow::Result<T>,

--- a/eugene/src/lib.rs
+++ b/eugene/src/lib.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use anyhow::anyhow;
 use postgres::{Client, NoTls, Transaction};
 
+use crate::script_discovery::ReadFrom;
 use tracing::trace_transaction;
 
 use crate::sqltext::sql_statements;
@@ -50,6 +51,29 @@ mod render_doc_snapshots;
 /// This module is for creating and destroying postgres
 /// database instances for eugene to trace.
 pub mod tempserver;
+
+pub struct SqlScript {
+    pub name: String,
+    pub sql: String,
+}
+
+/// Read a SQL script from a source and resolve placeholders.
+///
+/// # Arguments
+///
+/// * `read_from` - A source to read the SQL script from.
+/// * `placeholders` - A map of placeholders to resolve if found in the SQL script.
+pub fn read_script(
+    read_from: &ReadFrom,
+    placeholders: &HashMap<&str, &str>,
+) -> anyhow::Result<SqlScript> {
+    let sql = read_from.read()?;
+    let sql = sqltext::resolve_placeholders(&sql, placeholders)?;
+    Ok(SqlScript {
+        name: read_from.name().to_string(),
+        sql,
+    })
+}
 
 /// Connection settings for connecting to a PostgreSQL database.
 pub struct ClientSource {
@@ -120,20 +144,6 @@ impl WithClient for ClientSource {
         }
     }
 }
-/// Settings for tracing locks taken by SQL statements.
-pub struct TraceSettings<'a> {
-    name: String,
-    sql: &'a str,
-    commit: bool,
-}
-
-impl<'a> TraceSettings<'a> {
-    /// Create a new TraceSettings instance.
-    pub fn new(name: String, sql: &'a str, commit: bool) -> TraceSettings<'a> {
-        TraceSettings { name, sql, commit }
-    }
-}
-
 /// Parse placeholders in the form of name=value into a map.
 pub fn parse_placeholders(placeholders: &[String]) -> anyhow::Result<HashMap<&str, &str>> {
     let mut map = HashMap::new();
@@ -150,13 +160,14 @@ pub fn parse_placeholders(placeholders: &[String]) -> anyhow::Result<HashMap<&st
 /// Perform a lock trace of a SQL script and optionally commit the transaction, depending on
 /// trace_settings.
 pub fn perform_trace<'a, T: WithClient>(
-    trace: &TraceSettings,
+    script: &SqlScript,
     connection_settings: &mut T,
     ignored_hints: &'a [&'a str],
+    commit: bool,
 ) -> anyhow::Result<TxLockTracer<'a>> {
-    let sql_statements = sql_statements(trace.sql)?;
+    let sql_statements = sql_statements(script.sql.as_str())?;
     let all_concurrently = sql_statements.iter().all(sqltext::is_concurrently);
-    if all_concurrently && trace.commit {
+    if all_concurrently && commit {
         connection_settings.with_client(|client| {
             for s in sql_statements.iter() {
                 client.execute(*s, &[])?;
@@ -165,14 +176,14 @@ pub fn perform_trace<'a, T: WithClient>(
         })?;
 
         Ok(TxLockTracer::tracer_for_concurrently(
-            Some(trace.name.clone()),
+            Some(script.name.clone()),
             sql_statements.iter(),
             ignored_hints,
         ))
     } else {
-        connection_settings.in_transaction(trace.commit, |conn| {
+        connection_settings.in_transaction(commit, |conn| {
             trace_transaction(
-                Some(trace.name.clone()),
+                Some(script.name.clone()),
                 conn,
                 sql_statements.iter(),
                 ignored_hints,

--- a/eugene/src/render_doc_snapshots.rs
+++ b/eugene/src/render_doc_snapshots.rs
@@ -14,7 +14,7 @@ use serde::Serialize;
 use crate::lints::lint;
 use crate::output::{full_trace_data, GenericHint, Settings};
 use crate::script_discovery::{discover_scripts, script_filters, SortMode};
-use crate::{generate_new_test_db, hint_data, output, perform_trace, ClientSource, TraceSettings};
+use crate::{generate_new_test_db, hint_data, output, perform_trace, ClientSource, SqlScript};
 
 static DEFAULT_SETTINGS: Lazy<Settings> = Lazy::new(|| Settings::new(true, true));
 static HBARS: Lazy<Handlebars> = Lazy::new(|| {
@@ -105,8 +105,9 @@ fn snapshot_trace(id: &str, subfolder: &str, output_settings: &Settings) -> Resu
     for script in sources {
         let path = script.name().replace('\\', "/");
         let sql = script.read()?;
-        let trace_settings = TraceSettings::new(path, &sql, true);
-        let trace = perform_trace(&trace_settings, &mut connection_settings, &[])?;
+        let sql_script = SqlScript { name: path, sql };
+
+        let trace = perform_trace(&sql_script, &mut connection_settings, &[], true)?;
         let mut report = full_trace_data(&trace, *output_settings);
 
         // Try to make the report deterministic

--- a/eugene/src/render_doc_snapshots.rs
+++ b/eugene/src/render_doc_snapshots.rs
@@ -14,9 +14,7 @@ use serde::Serialize;
 use crate::lints::lint;
 use crate::output::{full_trace_data, GenericHint, Settings};
 use crate::script_discovery::{discover_scripts, script_filters, SortMode};
-use crate::{
-    generate_new_test_db, hint_data, output, perform_trace, ConnectionSettings, TraceSettings,
-};
+use crate::{generate_new_test_db, hint_data, output, perform_trace, ClientSource, TraceSettings};
 
 static DEFAULT_SETTINGS: Lazy<Settings> = Lazy::new(|| Settings::new(true, true));
 static HBARS: Lazy<Handlebars> = Lazy::new(|| {
@@ -95,7 +93,7 @@ fn snapshot_trace(id: &str, subfolder: &str, output_settings: &Settings) -> Resu
     let example_path = format!("examples/{}/{}", id, subfolder);
     let mut reports = vec![];
     let db = generate_new_test_db();
-    let mut connection_settings = ConnectionSettings::new(
+    let mut connection_settings = ClientSource::new(
         "postgres".to_string(),
         db.clone(),
         "localhost".to_string(),

--- a/eugene/src/tempserver.rs
+++ b/eugene/src/tempserver.rs
@@ -3,7 +3,7 @@ use std::process::{Child, Command};
 use std::sync::mpsc::channel;
 use std::thread::{spawn, JoinHandle};
 
-use crate::{ConnectionSettings, WithClient};
+use crate::{ClientSource, WithClient};
 use anyhow::{anyhow, Context, Result};
 use log::{debug, error, info, warn};
 use postgres::Client;
@@ -14,7 +14,7 @@ pub struct TempServer {
     child: Child,
     reader: Option<JoinHandle<()>>,
     logger: Option<JoinHandle<()>>,
-    connection_settings: ConnectionSettings,
+    connection_settings: ClientSource,
 }
 
 impl TempServer {
@@ -105,7 +105,7 @@ impl TempServer {
             child,
             reader: Some(reader),
             logger: Some(logger),
-            connection_settings: ConnectionSettings::new(
+            connection_settings: ClientSource::new(
                 "postgres".to_string(),
                 "postgres".to_string(),
                 "localhost".to_string(),


### PR DESCRIPTION
This is preparation for #97 -- gathers up shared options for lint and trace into a struct and pull out shared logic for parsing. A side effect is that args are now listed in the same order for help texts, and help texts are identical for the same options.