### PR TITLE
Let eugene filter out unmodified scripts using git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "eugene"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "eugene-web"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["eugene", "eugene-web"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 description = "Careful with That Lock, Eugene"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM postgres:alpine
 
-
 ARG TARGETARCH
+RUN apk add git
 COPY ./eugene-${TARGETARCH} /usr/local/bin/eugene
 RUN chmod +x /usr/local/bin/eugene
 
 RUN adduser -D eugene
 USER eugene
+
 
 ENTRYPOINT ["/usr/local/bin/eugene"]

--- a/eugene/docs/src/lint.md
+++ b/eugene/docs/src/lint.md
@@ -18,6 +18,9 @@ have reasonably precise rules. Some SQL statements will implicitly create indexe
 will prevent writes to the table, and `eugene lint` will catch those that it knows about,
 but there may be some ways for this to happen that it doesn't know about.
 
+If you want to run `eugene lint` in CI, or as a pre-commit hook, you can use `--git-diff=main`
+or `-gmain` to lint files that are new/unstaged, or have changes in them since `main`.
+
 ## Usage
 
 ```shell

--- a/eugene/docs/src/shell_output/lint
+++ b/eugene/docs/src/shell_output/lint
@@ -55,5 +55,10 @@ Options:
   -s, --skip-summary
           Skip the summary section for markdown output
 
+  -g, --git-diff <GIT_DIFF>
+          Filter out discovered scripts that are have not been changed since this git ref
+          
+          Pass a git ref, like a commit hash, tag, or branch name.
+
   -h, --help
           Print help (see a summary with '-h')

--- a/eugene/docs/src/shell_output/trace
+++ b/eugene/docs/src/shell_output/trace
@@ -59,6 +59,11 @@ Options:
   -s, --skip-summary
           Skip the summary section for markdown output
 
+  -g, --git-diff <GIT_DIFF>
+          Filter out discovered scripts that are have not been changed since this git ref
+          
+          Pass a git ref, like a commit hash, tag, or branch name.
+
       --disable-temporary
           Disable creation of temporary postgres server for tracing
           

--- a/eugene/docs/src/trace.md
+++ b/eugene/docs/src/trace.md
@@ -18,6 +18,10 @@ created in a transaction, even if they were implicitly created. If you need to t
 `eugene trace` that you know a statement to be safe, you can tell it to ignore a lint by
 adding a comment to your SQL script, see [ignores](/eugene/docs/ignores).
 
+If you want to run `eugene trace` in CI, or as a pre-commit hook, you can use `--git-diff=main`
+or `-gmain` to trace files that are new/unstaged, or have changes in them since `main`. 
+`eugene trace` will still run all the scripts, but will only check the ones that have changed.
+
 ## Usage
 
 ```shell

--- a/eugene/src/error.rs
+++ b/eugene/src/error.rs
@@ -64,6 +64,19 @@ where
     }
 }
 
+impl ContextualError for Error {
+    fn with_context<S: Into<String>>(mut self, ctx: S) -> Error {
+        self.context.push(ctx.into());
+        self
+    }
+}
+
+impl<T> ContextualResult<T, Error> for Result<T, Error> {
+    fn with_context<S: Into<String>>(self, ctx: S) -> Result<T, Error> {
+        self.map_err(|e| e.with_context(ctx))
+    }
+}
+
 #[derive(Debug)]
 pub enum InnerError {
     #[allow(dead_code)]
@@ -97,6 +110,12 @@ pub enum InnerError {
     SendError,
     SerdeError(serde_json::Error),
     PgPassEntryNotFound,
+    InvalidGitMode,
+    NoGitExecutableError,
+    NoGitRepositoryError,
+    GitExecutionError,
+    GitError,
+    InvalidPath,
 }
 
 impl From<serde_json::Error> for InnerError {

--- a/eugene/src/git.rs
+++ b/eugene/src/git.rs
@@ -1,0 +1,422 @@
+use log::trace;
+use std::fmt::Debug;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::error::{ContextualError, ContextualResult, InnerError};
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum GitMode {
+    DiffWith(String),
+    Disabled,
+}
+
+impl From<Option<String>> for GitMode {
+    fn from(value: Option<String>) -> Self {
+        match value {
+            Some(v) => GitMode::DiffWith(v),
+            None => GitMode::Disabled,
+        }
+    }
+}
+
+fn git_is_on_path() -> crate::Result<()> {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .map_err(|e| {
+            InnerError::NoGitExecutableError
+                .with_context(format!("Failed to execute `git --version`: {e}"))
+        })
+        .map(|_| ())
+}
+
+fn git_ref_exists<P: AsRef<Path>>(gitref: &str, cwd: P) -> crate::Result<()> {
+    Command::new("git")
+        .arg("rev-parse")
+        .arg("--verify")
+        .arg(gitref)
+        .current_dir(cwd.as_ref())
+        .output()
+        .map_err(|e| {
+            InnerError::GitError.with_context(format!(
+                "Failed to execute `git rev-parse --abbrev-ref {gitref}`: {e}"
+            ))
+        })
+        .and_then(|o| {
+            if o.status.success() {
+                Ok(())
+            } else {
+                Err(InnerError::GitError.with_context(format!("Git ref {gitref} not found")))
+            }
+        })
+}
+
+/// Find the nearest directory containing the given path, useful for setting cwd for git
+fn nearest_directory<P: AsRef<Path>>(path: P) -> crate::Result<PathBuf> {
+    let path = path.as_ref();
+    let p = Path::new(path);
+    if p.is_file() {
+        // p must have a parent, so we can unwrap it
+        Ok(p.parent().unwrap().into())
+    } else if p.is_dir() {
+        Ok(p.into())
+    } else if p.is_symlink() {
+        // For now, symlink is not supported
+        Err(InnerError::NotFound.with_context(format!(
+            "{path:?} is a symlink which is unsupported by eugene::git"
+        )))
+    } else {
+        Err(InnerError::NotFound.with_context(format!("{path:?} does not exist")))
+    }
+}
+
+fn git_status<P: AsRef<Path>>(cwd: P) -> crate::Result<String> {
+    let cwd = cwd.as_ref();
+    Command::new("git")
+        .arg("status")
+        .arg("--porcelain")
+        .current_dir(cwd)
+        .output()
+        .map_err(|e| {
+            InnerError::GitError.with_context(format!(
+                "Failed to execute `git status --porcelain` in {cwd:?}: {e}"
+            ))
+        })
+        .map(|output| String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Discover unstaged files in the path, which may be either a file or directory
+///
+/// Fails if the path does not exist, or isn't in a git repository
+fn unstaged_children<P: AsRef<Path>>(path: P) -> crate::Result<Vec<String>> {
+    let path = path.as_ref();
+    trace!("Checking if {path:?} has unstaged");
+    let cwd = nearest_directory(path)?;
+    // p exists
+    if path.is_file() {
+        // cwd is the parent and if `git status --porcelain` inside cwd contains `?? p`
+        // it is unstaged and will be the only output. We can unwrap here because `p` is a file
+        let file_name = path.file_name().unwrap().to_str().ok_or_else(|| {
+            InnerError::InvalidPath.with_context(format!("{path:?} contains non utf-8 characters"))
+        })?;
+        let status = git_status(&cwd).with_context(format!("Check if {path:?} is unstaged"))?;
+        trace!("git status --porcelain in {cwd:?} is {status}");
+        let look_for = format!("?? {file_name}");
+        if status.lines().any(|l| l.starts_with(&look_for)) {
+            let as_string = path.to_str().ok_or_else(|| {
+                InnerError::InvalidPath
+                    .with_context(format!("{path:?} contains non utf-8 characters"))
+            })?;
+            Ok(vec![as_string.to_string()])
+        } else {
+            Ok(vec![])
+        }
+    } else {
+        // cwd is the directory itself. We will use it as the working dir and join all the
+        // paths in the output to cwd to produce results, using only the lines that start with `??`
+        let status =
+            git_status(&cwd).with_context(format!("Check if {path:?} contains unstaged"))?;
+        trace!("git status --porcelain in {cwd:?} is {status}");
+        Ok(status
+            .lines()
+            .filter(|l| l.starts_with("??"))
+            .map(|l| {
+                let file_name = l.trim_start_matches("?? ").trim();
+                cwd.join(file_name).to_str().unwrap().to_string()
+            })
+            .collect())
+    }
+}
+
+fn git_diff_name_only(cwd: &Path, gitref: &str) -> Command {
+    let mut cmd = Command::new("git");
+    cmd.arg("diff")
+        .arg("--name-only")
+        .arg("--relative")
+        .arg(gitref)
+        .current_dir(cwd);
+    cmd
+}
+
+fn diff_files_since_ref<P: AsRef<Path> + Debug>(
+    path: P,
+    gitref: &str,
+) -> crate::Result<Vec<String>> {
+    let path = path.as_ref();
+    let cwd = nearest_directory(path)?;
+    git_ref_exists(gitref, &cwd)?;
+    let mut cmd = git_diff_name_only(&cwd, gitref);
+    if path.is_file() {
+        // cwd is above; if `git diff --name-only` in cwd name of `path`, it changed
+        let output = cmd.output().with_context(format!(
+            "Failed to execute `git diff --name-only {gitref}` in {cwd:?}"
+        ))?;
+        let string_ouput = String::from_utf8_lossy(&output.stdout);
+        trace!("git diff --name-only {gitref} in {cwd:?} is {string_ouput}");
+        // We can unwrap file_name here because `p` is a file
+        let file_name = path.file_name().unwrap().to_str().ok_or_else(|| {
+            InnerError::InvalidPath.with_context(format!("{path:?} contains non utf-8 characters"))
+        })?;
+        let as_string = path.to_str().ok_or_else(|| {
+            InnerError::InvalidPath.with_context(format!("{path:?} contains non utf-8 characters"))
+        })?;
+        if string_ouput.lines().any(|l| l == file_name) {
+            Ok(vec![as_string.to_string()])
+        } else {
+            Ok(vec![])
+        }
+    } else {
+        // cwd is the directory itself. We will use it as the working dir and join all the
+        // paths in the output to cwd to produce results
+        let output = cmd.output().with_context(format!(
+            "Failed to execute `git diff --name-only {gitref}` in {cwd:?}"
+        ))?;
+        let string_output = String::from_utf8_lossy(&output.stdout);
+        trace!("git diff --name-only {gitref} in {cwd:?} is {string_output}");
+        let r: crate::Result<Vec<_>> = string_output
+            .lines()
+            .map(|l| {
+                let file_name = l.trim();
+                Ok(cwd
+                    .join(file_name)
+                    .to_str()
+                    .ok_or_else(|| {
+                        InnerError::InvalidPath
+                            .with_context(format!("{path:?} contains invalid utf-8 characters"))
+                    })?
+                    .to_string())
+            })
+            .collect();
+        Ok(r?)
+    }
+}
+
+#[derive(Debug)]
+pub struct AllowList {
+    paths: Vec<String>,
+}
+
+#[derive(Debug)]
+pub enum GitFilter {
+    Ignore,
+    OneOf(AllowList),
+}
+
+impl GitFilter {
+    pub fn new<P: AsRef<Path> + Debug>(path: P, mode: GitMode) -> crate::Result<GitFilter> {
+        match mode {
+            GitMode::Disabled => Ok(GitFilter::Ignore),
+            GitMode::DiffWith(refname) => {
+                git_is_on_path()?;
+                let path = path.as_ref();
+                let mut diff = diff_files_since_ref(path, &refname)?;
+                diff.extend(unstaged_children(path)?);
+                Ok(GitFilter::OneOf(AllowList { paths: diff }))
+            }
+        }
+    }
+
+    pub fn empty(mode: GitMode) -> GitFilter {
+        match mode {
+            GitMode::Disabled => GitFilter::Ignore,
+            GitMode::DiffWith(_) => GitFilter::OneOf(AllowList { paths: vec![] }),
+        }
+    }
+
+    pub fn allows<S: AsRef<str>>(&self, path: S) -> bool {
+        let path = path.as_ref();
+        match self {
+            GitFilter::Ignore => true,
+            GitFilter::OneOf(allow_list) => allow_list.paths.iter().any(|p| p == path),
+        }
+    }
+
+    pub fn extend(&mut self, other: GitFilter) {
+        if let (GitFilter::OneOf(mine), GitFilter::OneOf(theirs)) = (self, other) {
+            mine.paths.extend(theirs.paths);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    struct RestoreContext {
+        restore: Option<Box<dyn FnOnce()>>,
+    }
+
+    impl RestoreContext {
+        fn new<F: FnOnce() + 'static>(restore: F) -> Self {
+            Self {
+                restore: Some(Box::new(restore)),
+            }
+        }
+    }
+
+    impl Drop for RestoreContext {
+        fn drop(&mut self) {
+            let inner = self.restore.take();
+            if let Some(restore) = inner {
+                restore();
+            }
+        }
+    }
+
+    fn set_path(new: &str) -> RestoreContext {
+        let old = std::env::var("PATH").unwrap();
+        std::env::set_var("PATH", new);
+        RestoreContext::new(move || std::env::set_var("PATH", old))
+    }
+
+    fn configure_git(path: &Path) {
+        Command::new("git")
+            .arg("init")
+            .arg("-b")
+            .arg("main")
+            .current_dir(path)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .arg("config")
+            .arg("user.email")
+            .arg("ci@example.com")
+            .current_dir(path)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .arg("config")
+            .arg("user.name")
+            .arg("ci@example.com")
+            .current_dir(path)
+            .output()
+            .unwrap();
+    }
+
+    #[test]
+    fn test_nearest_dir() {
+        let tmp = TempDir::new().unwrap();
+        let fp = tmp.path().join("foo");
+        std::fs::write(&fp, "").unwrap();
+        assert_eq!(nearest_directory(fp).unwrap(), tmp.path());
+        assert_eq!(nearest_directory(tmp.path()).unwrap(), tmp.path());
+        let subdir = tmp.path().join("subdir");
+        std::fs::create_dir(&subdir).unwrap();
+        assert_eq!(&nearest_directory(&subdir).unwrap(), &subdir);
+        let notexists = tmp.path().join("notexists");
+        assert!(nearest_directory(notexists).is_err());
+    }
+
+    #[test]
+    fn test_is_git_in_path() {
+        assert!(git_is_on_path().is_ok());
+        let _tmp = set_path("");
+        assert!(git_is_on_path().is_err());
+    }
+
+    #[test]
+    fn test_unstaged() {
+        let tmp = TempDir::new().unwrap();
+        Command::new("git")
+            .arg("init")
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        assert!(unstaged_children(tmp.path().to_str().unwrap())
+            .unwrap()
+            .is_empty());
+        assert!(unstaged_children(tmp.path().join("foo").to_str().unwrap()).is_err());
+        let fp = tmp.path().join("foo");
+        std::fs::write(&fp, "hei").unwrap();
+        assert_eq!(
+            unstaged_children(fp.to_str().unwrap()).unwrap(),
+            vec![fp.to_str().unwrap()]
+        );
+    }
+
+    #[test]
+    fn test_gitref_exists() {
+        let tmp = TempDir::new().unwrap();
+        configure_git(tmp.path());
+        assert!(git_ref_exists("main", tmp.path()).is_err());
+        let fp = tmp.path().join("foo");
+        std::fs::write(fp, "hei").unwrap();
+        let o = Command::new("git")
+            .arg("add")
+            .arg("foo")
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        eprintln!("{o:?}");
+        let o = Command::new("git")
+            .arg("commit")
+            .arg("-m")
+            .arg("initial")
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        eprintln!("{o:?}");
+        assert!(git_ref_exists("main", tmp.path()).is_ok());
+        assert!(git_ref_exists("nonono", tmp.path()).is_err());
+    }
+
+    #[test]
+    fn test_diff() {
+        let tmp = TempDir::new().unwrap();
+        configure_git(tmp.path());
+        let fp = tmp.path().join("foo");
+        std::fs::write(&fp, "hei").unwrap();
+        Command::new("git")
+            .arg("add")
+            .arg("foo")
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        Command::new("git")
+            .arg("commit")
+            .arg("-m")
+            .arg("initial")
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        assert!(diff_files_since_ref(&fp, "main").unwrap().is_empty(),);
+        Command::new("git")
+            .arg("checkout")
+            .arg("-b")
+            .arg("newbranch")
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        let fp2 = tmp.path().join("bar");
+        std::fs::write(&fp2, "hei").unwrap();
+        Command::new("git")
+            .arg("add")
+            .arg("bar")
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        Command::new("git")
+            .arg("commit")
+            .arg("-m")
+            .arg("new file")
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        // The new file is contained in the diff with main
+        assert_eq!(
+            diff_files_since_ref(&fp2, "main").unwrap(),
+            vec![fp2.to_str().unwrap()]
+        );
+        assert_eq!(
+            diff_files_since_ref(tmp.path(), "main").unwrap(),
+            vec![fp2.to_str().unwrap()]
+        );
+
+        // Change fp
+    }
+}

--- a/eugene/src/lib.rs
+++ b/eugene/src/lib.rs
@@ -56,6 +56,9 @@ pub mod tempserver;
 
 pub mod error;
 
+/// Utilities for invoking git
+pub mod git;
+
 pub struct SqlScript {
     pub name: String,
     pub sql: String,

--- a/eugene/src/script_discovery.rs
+++ b/eugene/src/script_discovery.rs
@@ -7,7 +7,7 @@ use crate::error::InnerError::{
     PathParseError, UnknownPathType,
 };
 use crate::error::{ContextualError, ContextualResult};
-use log::trace;
+use log::{debug, trace};
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::{anychar, char, digit1};
@@ -381,7 +381,9 @@ pub fn discover_all<S: AsRef<str>, T: IntoIterator<Item = S>>(
 ) -> crate::Result<Vec<ReadFrom>> {
     let mut all = vec![];
     for path in paths {
-        all.extend(discover_scripts(path.as_ref(), filter, SortMode::Unsorted)?);
+        let path = path.as_ref();
+        debug!("Discovering scripts from: {:?}", path);
+        all.extend(discover_scripts(path, filter, SortMode::Unsorted)?);
     }
 
     let any_is_dir = all


### PR DESCRIPTION
By passing -g main, `eugene lint` and `eugene trace` can ignore scripts that are identical on the main branch. This makes it much easier to use eugene in CI, since it can do something useful on feature branches. `-g` accepts an arbitrary gitref expression such as a tag or `HEAD~100` etc. For now it defaults to being disabled.

Feels like this is going to be as close as we're getting to #89 and #35, which are both fundamentally about the same thing. Need to document this before we merge it.