### PR TITLE
Improve comment action ignore doc and error message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "eugene"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "eugene-web"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["eugene", "eugene-web"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "Careful with That Lock, Eugene"
 categories = [

--- a/eugene/docs/src/hints/W14/safer_lint.md
+++ b/eugene/docs/src/hints/W14/safer_lint.md
@@ -89,4 +89,4 @@ Statement takes lock on `public.authors`, but does not set a lock timeout.
 
 ##### `W14`: [Adding a primary key using an index](https://kaveland.no/eugene/hints/W14/)
 
-New primary key constraint using index on `public.authors`, may cause postgres to `SET NOT NULL` on columns in the index. This lint may be a false positive if the columns are already `NOT NULL`, ignore it by commenting the statement with `-- eugene: ignore: W14`.
+New primary key constraint using index on `public.authors`, may cause postgres to `SET NOT NULL` on columns in the index. This lint may be a false positive if the columns are already `NOT NULL`, ignore it by commenting the statement with `-- eugene: ignore W14`.

--- a/eugene/docs/src/hints/W14/unsafe_lint.md
+++ b/eugene/docs/src/hints/W14/unsafe_lint.md
@@ -64,4 +64,4 @@ alter table authors
 
 ##### `W14`: [Adding a primary key using an index](https://kaveland.no/eugene/hints/W14/)
 
-New primary key constraint using index on `public.authors`, may cause postgres to `SET NOT NULL` on columns in the index. This lint may be a false positive if the columns are already `NOT NULL`, ignore it by commenting the statement with `-- eugene: ignore: W14`.
+New primary key constraint using index on `public.authors`, may cause postgres to `SET NOT NULL` on columns in the index. This lint may be a false positive if the columns are already `NOT NULL`, ignore it by commenting the statement with `-- eugene: ignore W14`.

--- a/eugene/docs/src/ignores.md
+++ b/eugene/docs/src/ignores.md
@@ -21,6 +21,6 @@ alter table books alter column title set not null;
 You can ignore specific rule IDs for a single statement:
 
 ```sql
--- eugene: ignore: E2, E3
+-- eugene: ignore E2, E3
 alter table books alter column title set not null;
 ```

--- a/eugene/src/bin/eugene.rs
+++ b/eugene/src/bin/eugene.rs
@@ -53,7 +53,7 @@ struct TraceAndLintOptions {
     ///
     /// Or comment your SQL statement like this:
     ///
-    /// `-- eugene-ignore: E3, E4`
+    /// `-- eugene ignore E3, E4`
     ///
     /// alter table foo add column bar json;
     ///
@@ -83,7 +83,7 @@ struct TraceAndLintOptions {
     /// Skip the summary section for markdown output
     #[arg(short = 's', long = "skip-summary", default_value_t = false)]
     skip_summary: bool,
-    /// Filter out discovered scripts that are have not been changed since this git ref
+    /// Filter out discovered scripts that have not been changed since this git ref
     ///
     /// Pass a git ref, like a commit hash, tag, or branch name.
     #[arg(short = 'g', long = "git-diff")]

--- a/eugene/src/comments.rs
+++ b/eugene/src/comments.rs
@@ -31,7 +31,10 @@ pub fn find_comment_action(sql: &str) -> crate::Result<LintAction> {
                     rem.split(',').map(|id| id.trim()).collect(),
                 ))
             }
-            _ => Err(BadCommentInstruction(format!("expected: 'ignore <id>[,<id>]', found: '{cap}'")).into()),
+            _ => Err(BadCommentInstruction(format!(
+                "expected: 'ignore <id>[,<id>]', found: '{cap}'"
+            ))
+            .into()),
         }
     } else {
         Ok(LintAction::Continue)

--- a/eugene/src/comments.rs
+++ b/eugene/src/comments.rs
@@ -31,7 +31,7 @@ pub fn find_comment_action(sql: &str) -> crate::Result<LintAction> {
                     rem.split(',').map(|id| id.trim()).collect(),
                 ))
             }
-            _ => Err(BadCommentInstruction(cap.to_string()).into()),
+            _ => Err(BadCommentInstruction(format!("expected: 'ignore <id>[,<id>]', found: '{cap}'")).into()),
         }
     } else {
         Ok(LintAction::Continue)

--- a/eugene/src/lints/rules.rs
+++ b/eugene/src/lints/rules.rs
@@ -440,7 +440,7 @@ fn add_primary_key_constraint_using_index(ctx: LintContext) -> Option<String> {
                         "New primary key constraint using index on `{schema}.{table}`, \
                     may cause postgres to `SET NOT NULL` on columns in the index. \
                     This lint may be a false positive if the columns are already `NOT NULL`, ignore it \
-                    by commenting the statement with `-- eugene: ignore: {}`", ADD_PRIMARY_KEY_USING_INDEX.id()
+                    by commenting the statement with `-- eugene: ignore {}`", ADD_PRIMARY_KEY_USING_INDEX.id()
                     ))
                 } else {
                     None


### PR DESCRIPTION
Fixes https://github.com/kaaveland/eugene/issues/123

Previous error message:
```shell
Error: Error checking stdin: BadCommentInstruction("ignore: E2, E3")
```
New error message:
```shell
Error: Error checking stdin: BadCommentInstruction("expected: 'ignore <id>[,<id>]', found: 'ignore: E2, E3'")
```